### PR TITLE
include minimum jvm version in launch command

### DIFF
--- a/src/server/install.ts
+++ b/src/server/install.ts
@@ -166,7 +166,7 @@ export class BazelBSPInstaller {
       .join(' ')
 
     // Full install command including flags.
-    const installCommand = `"${coursierPath}" launch ${MAVEN_PACKAGE}:${config.serverVersion} -M ${INSTALL_METHOD} -- ${flagsString}`
+    const installCommand = `"${coursierPath}" launch --jvm 11+ ${MAVEN_PACKAGE}:${config.serverVersion} -M ${INSTALL_METHOD} -- ${flagsString}`
 
     // Report progress in output channel.
     const installProcess = cp.spawn(installCommand, {cwd: root, shell: true})

--- a/src/test/suite/install.test.ts
+++ b/src/test/suite/install.test.ts
@@ -87,6 +87,7 @@ suite('BSP Installer', () => {
 
     // Just confirm that coursier path was part of the spawn call, to leave flexibility for other changes to the command.
     assert.ok(spawnStub.getCalls()[0].args[0].includes(coursierPath))
+    assert.ok(spawnStub.getCalls()[0].args[0].includes('--jvm 11+'))
     assert.ok(installResult)
   })
 


### PR DESCRIPTION
(migrating existing commit from internal repo)

Specify minimum --jvm argument when launching the BSP install command. This will allow coursier to attempt to find a version that matches if already installed, or download one that meets the requirements. This ensures a successful launch even in environments that do not have a new enough jvm version installed.
