### PR TITLE
Update publisher and version

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "vscode-bazel-bsp",
   "displayName": "Bazel Build Server Protocol (BSP)",
   "description": "Bazel BSP integration for VS Code.",
-  "version": "0.0.1",
+  "publisher": "Uber",
+  "version": "0.0.3",
   "license": "Apache-2.0",
   "repository": "https://github.com/uber/vscode-bazel-bsp",
   "engines": {


### PR DESCRIPTION
Last two items to migrate over:
- Updating the publisher name (missed while transferring this over)
- Update version number (skipping "0.0.2" as we used that internally).  This will give us a clean start moving forward in open source.

After this commit, this open source repo is caught up with the internal one and should be used moving forward for all future changes.