### PR TITLE
Use readFile instead of openTextDocument for regex test case discovery

### DIFF
--- a/src/test-explorer/resolver.ts
+++ b/src/test-explorer/resolver.ts
@@ -268,7 +268,14 @@ export class TestResolver implements OnModuleInit, vscode.Disposable {
     this.condenseTestItems(parentTest)
 
     // Kick off test case resolution within each of the target's documents.
+    let counter = 1
     for (const doc of allDocumentTestItems) {
+      updateDescription(
+        parentTest,
+        `Loading: analyzing test cases in file ${counter++} of ${
+          allDocumentTestItems.length
+        }`
+      )
       await this.resolveDocumentTestCases(doc, cancellationToken)
 
       if (doc.uri) {
@@ -280,6 +287,7 @@ export class TestResolver implements OnModuleInit, vscode.Disposable {
         this.store.updateTestItemWatcher(doc.id, watcher)
       }
     }
+    updateDescription(parentTest)
   }
 
   private async resolveDocumentTestCases(

--- a/src/test/suite/language-tools/java.test.ts
+++ b/src/test/suite/language-tools/java.test.ts
@@ -34,7 +34,7 @@ suite('Java Language Tools', () => {
     testController.dispose()
   })
 
-  test('process test cases', async () => {
+  test('process test cases, example 1', async () => {
     const result = await languageTools.getDocumentTestCases(
       vscode.Uri.file(
         path.join(fixtureDir, 'language_files', 'SampleValidExampleTest.java')
@@ -55,6 +55,29 @@ suite('Java Language Tools', () => {
     }
     assert.equal(result.documentTest?.testFilter, expectedBaseTestFilter)
     assert.equal(result.documentTest?.name, 'SampleValidExampleTest')
+  })
+
+  test('process test cases, example 2', async () => {
+    const result = await languageTools.getDocumentTestCases(
+      vscode.Uri.file(
+        path.join(fixtureDir, 'language_files', 'TestSampleValidExample.java')
+      )
+    )
+
+    assert.strictEqual(result.isTestFile, true)
+    assert.strictEqual(result.testCases.length, 2)
+
+    const expectedBaseTestFilter =
+      'com.sample.project.common.client.samplepackage.TestSampleValidExample'
+
+    const expectedTests = ['testGetInstance', 'testGetSampleClient']
+    for (const test of result.testCases) {
+      assert.ok(expectedTests.includes(test.name))
+      assert.ok(test.testFilter.startsWith(expectedBaseTestFilter))
+      assert.ok(test.testFilter.endsWith(test.name))
+    }
+    assert.equal(result.documentTest?.testFilter, expectedBaseTestFilter)
+    assert.equal(result.documentTest?.name, 'TestSampleValidExample')
   })
 
   test('no matching test class name', async () => {

--- a/src/test/testdata/language_files/TestSampleValidExample.java
+++ b/src/test/testdata/language_files/TestSampleValidExample.java
@@ -1,0 +1,26 @@
+package com.sample.project.common.client.samplepackage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.uber.testing.base.TestBase;
+import org.junit.Test;
+
+public class TestSampleValidExample extends TestBase {
+  @Test
+  public void testGetInstance() {
+    SampleClientProvider instance =
+        SampleClientProvider.getInstance("sample");
+    assertNotNull(instance);
+  }
+
+  @Test
+  public void testGetSampleClient() {
+    SampleClientProvider instance =
+        SampleClientProvider.getInstance("sample");
+    StatementRenderingClient clientA = instance.getSampleClient();
+    StatementRenderingClient clientB = instance.getSampleClient();
+    assertNotNull(clientA);
+    assertEquals(clientA, clientB);
+  }
+}


### PR DESCRIPTION
Using vscode's openTextDocument has side effects that add overhead, including sending events to other extensions and language servers.

Switching to the fs.readFile api instead, which allows us to get the text without the additional overhead, making the discovery feel much more responsive to the user and also avoiding overloading language servers with a series of unnecessary didOpen events.

Also slightly adjust regex to be more flexible for class names.