### PR TITLE
Adjust notifications during sync

### DIFF
--- a/src/test-explorer/resolver.ts
+++ b/src/test-explorer/resolver.ts
@@ -48,7 +48,7 @@ export class TestResolver implements OnModuleInit, vscode.Disposable {
     await vscode.window.withProgress(
       {
         location: vscode.ProgressLocation.Notification,
-        title: 'Syncing Bazel Test Targets',
+        title: 'Refreshing Test Cases',
         cancellable: true,
       },
       async (
@@ -93,12 +93,22 @@ export class TestResolver implements OnModuleInit, vscode.Disposable {
 
         switch (parentMetadata?.type) {
           case TestItemType.Root:
+            progress.report({
+              message:
+                'Fetching test targets from build server ([progress](command:bazelbsp.showServerOutput))',
+            })
             await this.resolveTargets(parentTest, combinedToken)
             break
           case TestItemType.BazelTarget:
+            progress.report({
+              message: `Fetching source files in ${parentMetadata.target?.displayName}`,
+            })
             await this.resolveSourceFiles(parentTest, combinedToken)
             break
           case TestItemType.SourceFile:
+            progress.report({
+              message: `Finding test cases in ${parentMetadata.testItem.label}`,
+            })
             await this.resolveDocumentTestCases(parentTest, combinedToken)
         }
       }


### PR DESCRIPTION
Adjusting the progress notification format to be more specific based on the type of test item being resolved.
- This will help disambiguate in cases where work is in progress for multiple test items in the tree
- Avoids the case of a user seeing multiple of the same generic notification with no additional detail
- Also only include the output channel link for the fetching targets step, as there is server output for this one but not the others