### PR TITLE
Show setup message when no targets returned from sync

### DIFF
--- a/src/test-explorer/resolver.ts
+++ b/src/test-explorer/resolver.ts
@@ -434,7 +434,7 @@ const gettingStartedMessage = new vscode.MarkdownString(
   - Ensure that the bazel_binary field in this file matches the path to your Bazel binary.
   - Re-sync at any time by clicking the $(extensions-refresh) refresh icon at the very top of the testing panel.
 
-  Does it seem like something else went wrong? Check for output [here](command:bazelbsp.showServerOutput).
+  Think something else went wrong? Check the output [here](command:bazelbsp.showServerOutput).
   `,
   true
 )

--- a/src/test-info/test-item-factory.ts
+++ b/src/test-info/test-item-factory.ts
@@ -36,6 +36,7 @@ export class TestItemFactory {
       'Bazel Test Targets',
       uri
     )
+    newTest.range = new vscode.Range(0, 0, 0, 0)
     newTest.canResolveChildren = true
     this.store.testCaseMetadata.set(
       newTest,

--- a/src/test/suite/resolver.test.ts
+++ b/src/test/suite/resolver.test.ts
@@ -344,6 +344,30 @@ suite('Test Resolver', () => {
       }
     })
 
+    test('no targets returned', async () => {
+      const root = testCaseStore.testController.createTestItem(
+        'root',
+        'Bazel Test Targets'
+      )
+      testCaseStore.testController.items.add(root)
+      testCaseStore.testCaseMetadata.set(
+        root,
+        new TestCaseInfo(root, undefined, TestItemType.Root)
+      )
+      assert.ok(testCaseStore.testController.resolveHandler)
+
+      // Simulate an empty result from requesting targets.
+      const emptyResult: bsp.WorkspaceBuildTargetsResult = {
+        targets: [],
+      }
+      const sendRequestStub = sandbox
+        .stub(sampleConn, 'sendRequest')
+        .resolves(emptyResult)
+      await testCaseStore.testController.resolveHandler(root)
+      const message = root.error as vscode.MarkdownString
+      assert.ok(message.value.includes('No test targets found'))
+    })
+
     test('source files within a target', async () => {
       const buildTarget = sampleBuildTargetsResult.targets[0]
       const sendRequestStub = sandbox


### PR DESCRIPTION
When a sync completes and returns no targets, it's likely that the user needs to make adjustments to their .bazelproject file.

This change adds guidance for the user to resolve issues and re-sync:
- When no targets are returned, error message shown immediately below the root item, with access to .bazelproject file.  This only supports one line, so we can't include full details here.
- Detailed instructions will be surfaced at the top of the .bazelproject file, and in the lower test results panel:

![image](https://github.com/uber/vscode-bazel-bsp/assets/92764374/38d3d462-a935-47eb-b6fa-0c988609e946)
![image](https://github.com/uber/vscode-bazel-bsp/assets/92764374/af770943-4193-4e0e-8cdd-abd85ddcb9a7)
