### PR TITLE
Add results from parameterized tests to parent

### DIFF
--- a/src/language-tools/java.ts
+++ b/src/language-tools/java.ts
@@ -11,6 +11,7 @@ const JAVA_TEST_REGEX =
   /@Test\s+.*\s+public void (?<methodName>\w+)|public class (?<className>(Test\w*|\w+Test))\s+extends/
 const PACKAGE_NAME_REGEX =
   /package\s+(?<packageName>([a-zA-Z_][a-zA-Z0-9_]*)(\.[a-zA-Z_][a-zA-Z0-9_]*)*);/
+const PARAMETERIZED_TEST_REGEX = /^(?<lookupKey>.*)\[(?<subTestName>.*)\]$/
 
 export class JavaLanguageTools implements LanguageTools {
   /**
@@ -22,7 +23,15 @@ export class JavaLanguageTools implements LanguageTools {
     if (testFinishData.dataKind === TestFinishDataKind.JUnitStyleTestCaseData) {
       const testCaseData = testFinishData.data as JUnitStyleTestCaseData
       if (testCaseData.className !== undefined) {
-        return `${testCaseData.className}.${testFinishData.displayName}`
+        let testCaseName = testFinishData.displayName
+
+        // In case of a parameterized test, keep the method name.
+        const match = testCaseName.match(PARAMETERIZED_TEST_REGEX)
+        if (match?.groups?.lookupKey) {
+          testCaseName = match.groups.lookupKey
+        }
+
+        return `${testCaseData.className}.${testCaseName}`
       } else {
         return testFinishData.displayName
       }

--- a/src/language-tools/python.ts
+++ b/src/language-tools/python.ts
@@ -8,6 +8,7 @@ import {BaseLanguageTools} from './base'
 import {JUnitStyleTestCaseData, TestFinishDataKind} from '../bsp/bsp-ext'
 
 const TEST_FILE_REGEX = /^(test_.+\.py|.+_test\.py)$/
+const PARAMETERIZED_TEST_REGEX = /^(?<lookupKey>.*)\[(?<subTestName>.*)\]$/
 
 export class PythonLanguageTools
   extends BaseLanguageTools
@@ -23,7 +24,15 @@ export class PythonLanguageTools
   mapTestFinishDataToLookupKey(testFinishData: TestFinish): string | undefined {
     if (testFinishData.dataKind === TestFinishDataKind.JUnitStyleTestCaseData) {
       const testCaseData = testFinishData.data as JUnitStyleTestCaseData
-      return `${testCaseData.className}.${testFinishData.displayName}`
+      let testCaseName = testFinishData.displayName
+
+      // In case of a parameterized test, keep the method name.
+      const match = testCaseName.match(PARAMETERIZED_TEST_REGEX)
+      if (match?.groups?.lookupKey) {
+        testCaseName = match.groups.lookupKey
+      }
+
+      return `${testCaseData.className}.${testCaseName}`
     }
     return undefined
   }

--- a/src/language-tools/python.ts
+++ b/src/language-tools/python.ts
@@ -8,7 +8,7 @@ import {BaseLanguageTools} from './base'
 import {JUnitStyleTestCaseData, TestFinishDataKind} from '../bsp/bsp-ext'
 
 const TEST_FILE_REGEX = /^(test_.+\.py|.+_test\.py)$/
-const PARAMETERIZED_TEST_REGEX = /^(?<lookupKey>.*)\[(?<subTestName>.*)\]$/
+const PARAMETERIZED_TEST_REGEX = /^(?<lookupKey>.*?)(?=\[.*?\])(.*)$/
 
 export class PythonLanguageTools
   extends BaseLanguageTools
@@ -22,7 +22,10 @@ export class PythonLanguageTools
    * @returns Lookup key to find this test case in the TestRunTracker.
    */
   mapTestFinishDataToLookupKey(testFinishData: TestFinish): string | undefined {
-    if (testFinishData.dataKind === TestFinishDataKind.JUnitStyleTestCaseData) {
+    if (
+      testFinishData.dataKind === TestFinishDataKind.JUnitStyleTestCaseData &&
+      testFinishData.data
+    ) {
       const testCaseData = testFinishData.data as JUnitStyleTestCaseData
       let testCaseName = testFinishData.displayName
 
@@ -32,7 +35,10 @@ export class PythonLanguageTools
         testCaseName = match.groups.lookupKey
       }
 
-      return `${testCaseData.className}.${testCaseName}`
+      // Use the class name as the base, and append the test case name if available.
+      let result = testCaseData.className
+      if (testCaseName.length > 0) result += `.${testCaseName}`
+      return result
     }
     return undefined
   }

--- a/src/test/suite/language-tools/java.test.ts
+++ b/src/test/suite/language-tools/java.test.ts
@@ -126,6 +126,17 @@ suite('Java Language Tools', () => {
       status: TestStatus.Failed,
     })
     assert.strictEqual(result, undefined)
+
+    result = languageTools.mapTestFinishDataToLookupKey({
+      displayName: 'myTest[example1]',
+      status: TestStatus.Failed,
+      dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+      data: {
+        time: 0,
+        className: 'com.example.ClassName',
+      },
+    })
+    assert.strictEqual(result, 'com.example.ClassName.myTest')
   })
 
   test('map test case info to lookup key', async () => {

--- a/src/test/suite/language-tools/python.test.ts
+++ b/src/test/suite/language-tools/python.test.ts
@@ -88,49 +88,242 @@ suite('Python Language Tools', () => {
     assert.ok(executeCommandStub.notCalled)
   })
 
-  test('map test finish data to lookup key', async () => {
-    let result = languageTools.mapTestFinishDataToLookupKey({
-      displayName: 'test_method',
-      status: TestStatus.Failed,
-      dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
-      data: {
-        time: 0,
-        className: 'my.example.test_example.TestMyClass',
+  const testCases = [
+    {
+      description: 'method within a class',
+      input: {
+        displayName: 'test_method',
+        status: TestStatus.Failed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 0,
+          className: 'my.example.test_example.TestMyClass',
+        },
       },
-    })
-    assert.strictEqual(
-      result,
-      'my.example.test_example.TestMyClass.test_method'
-    )
-
-    result = languageTools.mapTestFinishDataToLookupKey({
-      displayName: 'test_method',
-      status: TestStatus.Failed,
-      dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
-      data: {
-        time: 0,
-        className: 'my.example.test_example',
+      expected: 'my.example.test_example.TestMyClass.test_method',
+    },
+    {
+      description: 'standalone method',
+      input: {
+        displayName: 'test_method',
+        status: TestStatus.Failed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 0,
+          className: 'my.example.test_example',
+        },
       },
-    })
-    assert.strictEqual(result, 'my.example.test_example.test_method')
-
-    result = languageTools.mapTestFinishDataToLookupKey({
-      displayName: 'test_method[example1]',
-      status: TestStatus.Failed,
-      dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
-      data: {
-        time: 0,
-        className: 'my.example.test_example',
+      expected: 'my.example.test_example.test_method',
+    },
+    {
+      description: 'parameterized test result',
+      input: {
+        displayName: 'test_method[example1]',
+        status: TestStatus.Failed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 0,
+          className: 'my.example.test_example',
+        },
       },
-    })
-    assert.strictEqual(result, 'my.example.test_example.test_method')
+      expected: 'my.example.test_example.test_method',
+    },
+    {
+      description: 'parameterized test with special characters',
+      input: {
+        displayName: 'test_method[example1!@#]',
+        status: TestStatus.Passed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 1,
+          className: 'my.special.chars_example',
+        },
+      },
+      expected: 'my.special.chars_example.test_method',
+    },
+    {
+      description: 'parameterized test with spaces',
+      input: {
+        displayName: 'test_method[example with spaces]',
+        status: TestStatus.Skipped,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 0.5,
+          className: 'my.space.test_example',
+        },
+      },
+      expected: 'my.space.test_example.test_method',
+    },
+    {
+      description: 'parameterized test with multiple brackets',
+      input: {
+        displayName: 'test_method[example[inner]]',
+        status: TestStatus.Failed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 2,
+          className: 'my.multibracket.test_example',
+        },
+      },
+      expected: 'my.multibracket.test_example.test_method',
+    },
+    {
+      description: 'parameterized test with numbers',
+      input: {
+        displayName: 'test_method[12345]',
+        status: TestStatus.Passed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 0.1,
+          className: 'my.numeric.test_example',
+        },
+      },
+      expected: 'my.numeric.test_example.test_method',
+    },
+    {
+      description: 'parameterized test with empty brackets',
+      input: {
+        displayName: 'test_method[]',
+        status: TestStatus.Failed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 1.5,
+          className: 'my.emptybracket.test_example',
+        },
+      },
+      expected: 'my.emptybracket.test_example.test_method',
+    },
+    {
+      description: 'parameterized test with special symbols',
+      input: {
+        displayName: 'test_method[!@#$%^&*()]',
+        status: TestStatus.Skipped,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 3,
+          className: 'my.symbols.test_example',
+        },
+      },
+      expected: 'my.symbols.test_example.test_method',
+    },
+    {
+      description: 'parameterized test with long name',
+      input: {
+        displayName: 'test_method[averylongsubtestnamethatisunusuallylong]',
+        status: TestStatus.Failed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 2.5,
+          className: 'my.longname.test_example',
+        },
+      },
+      expected: 'my.longname.test_example.test_method',
+    },
+    {
+      description: 'parameterized test with nested brackets',
+      input: {
+        displayName: 'test_method[example[nested[brackets]]]',
+        status: TestStatus.Passed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 0.2,
+          className: 'my.nestedbrackets.test_example',
+        },
+      },
+      expected: 'my.nestedbrackets.test_example.test_method',
+    },
+    {
+      description: 'result with no data',
+      input: {
+        displayName: 'pytest',
+        status: TestStatus.Failed,
+      },
+      expected: undefined,
+    },
+    {
+      description: 'successful test case',
+      input: {
+        displayName: 'test_successful_method',
+        status: TestStatus.Passed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 1,
+          className: 'my.example.test_example.TestMyClass',
+        },
+      },
+      expected: 'my.example.test_example.TestMyClass.test_successful_method',
+    },
+    {
+      description: 'unknown dataKind',
+      input: {
+        displayName: 'unknown_test',
+        status: TestStatus.Failed,
+        dataKind: 'UnknownDataKind',
+        data: {
+          time: 0,
+          className: 'my.example.test_example.UnknownClass',
+        },
+      },
+      expected: undefined,
+    },
+    {
+      description: 'method with special characters',
+      input: {
+        displayName: 'test_method_with_special_chars!@#',
+        status: TestStatus.Failed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 0,
+          className: 'my.example.test_example.TestMyClass',
+        },
+      },
+      expected:
+        'my.example.test_example.TestMyClass.test_method_with_special_chars!@#',
+    },
+    {
+      description: 'method with numeric displayName',
+      input: {
+        displayName: '123456',
+        status: TestStatus.Failed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 0,
+          className: 'my.example.test_example.TestMyClass',
+        },
+      },
+      expected: 'my.example.test_example.TestMyClass.123456',
+    },
+    {
+      description: 'empty string as displayName',
+      input: {
+        displayName: '',
+        status: TestStatus.Failed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: {
+          time: 0,
+          className: 'my.example.test_example.TestMyClass',
+        },
+      },
+      expected: 'my.example.test_example.TestMyClass',
+    },
+    {
+      description: 'null data gracefully',
+      input: {
+        displayName: 'null_data_test',
+        status: TestStatus.Failed,
+        dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+        data: null,
+      },
+      expected: undefined,
+    },
+  ]
 
-    result = languageTools.mapTestFinishDataToLookupKey({
-      displayName: 'pytest',
-      status: TestStatus.Failed,
+  for (const testCase of testCases) {
+    test(`map test finish data to lookup key: ${testCase.description}`, async () => {
+      const result = languageTools.mapTestFinishDataToLookupKey(testCase.input)
+      assert.strictEqual(result, testCase.expected)
     })
-    assert.strictEqual(result, undefined)
-  })
+  }
 
   test('map test case info to lookup key', async () => {
     let testInfo = testController.createTestItem('test1', 'test1')

--- a/src/test/suite/language-tools/python.test.ts
+++ b/src/test/suite/language-tools/python.test.ts
@@ -115,6 +115,17 @@ suite('Python Language Tools', () => {
     assert.strictEqual(result, 'my.example.test_example.test_method')
 
     result = languageTools.mapTestFinishDataToLookupKey({
+      displayName: 'test_method[example1]',
+      status: TestStatus.Failed,
+      dataKind: TestFinishDataKind.JUnitStyleTestCaseData,
+      data: {
+        time: 0,
+        className: 'my.example.test_example',
+      },
+    })
+    assert.strictEqual(result, 'my.example.test_example.test_method')
+
+    result = languageTools.mapTestFinishDataToLookupKey({
       displayName: 'pytest',
       status: TestStatus.Failed,
     })


### PR DESCRIPTION
This update will ensure that the correct test case gets updated when a parameterized test is run:
- When test case results are sent back from the build server, a failure will be sent for each parameterized test case.
- Extract the original test case name (language-specific), which will be used to lookup the correct parent item
- Each entry, which contains the specific failure details for that entry, will now get added to the parent message.  This will surface the specific cases in the parameterized test that failed.
  Example:
  ![image](https://github.com/uber/vscode-bazel-bsp/assets/92764374/2cab4488-1d15-4fa3-8e81-8acfa37b25c2)

