### PR TITLE
Resolve based on open files

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
             "Do not install BSP server if not already present."
           ],
           "description": "Installation behavior for the build server."
+        },
+        "bazelbsp.autoExpandTarget": {
+          "type": "boolean",
+          "default": "true",
+          "description": "Find all tests within open files, without waiting for the file's target to be expanded in the Test Explorer."
         }
       }
     }

--- a/src/language-tools/base.ts
+++ b/src/language-tools/base.ts
@@ -28,7 +28,7 @@ export class BaseLanguageTools implements LanguageTools {
   /**
    * No support for individual test cases or test file identification.
    * @param document URI of the document to be analyzed for test cases.
-   * @returns Result always contains isTestFile value of true, and no test cases.
+   * @returns Result always contains isTestFile value of false, and no test cases.
    */
   async getDocumentTestCases(
     document: vscode.Uri,
@@ -36,7 +36,7 @@ export class BaseLanguageTools implements LanguageTools {
   ): Promise<TestFileContents> {
     return {
       // Do not filter out any files.
-      isTestFile: true,
+      isTestFile: false,
       // No test case discovery.
       testCases: [],
     }

--- a/src/language-tools/manager.ts
+++ b/src/language-tools/manager.ts
@@ -54,4 +54,13 @@ export class LanguageToolManager {
     }
     return this.baseLanguageTools
   }
+
+  getLanguageToolsForFile(document: vscode.TextDocument): LanguageTools {
+    if (document.languageId === 'python') {
+      return this.pythonLanguageTools
+    } else if (document.languageId === 'java') {
+      return this.javaLanguageTools
+    }
+    return this.baseLanguageTools
+  }
 }

--- a/src/test-explorer/store.ts
+++ b/src/test-explorer/store.ts
@@ -6,6 +6,7 @@ import {
   TEST_CONTROLLER_TOKEN,
 } from '../custom-providers'
 import {TestCaseInfo} from '../test-info/test-info'
+import {BuildTargetIdentifier} from 'src/bsp/bsp'
 
 export class TestCaseStore implements OnModuleInit, vscode.Disposable {
   @Inject(EXTENSION_CONTEXT_TOKEN) private readonly ctx: vscode.ExtensionContext
@@ -15,10 +16,14 @@ export class TestCaseStore implements OnModuleInit, vscode.Disposable {
 
   // Watcher to update a test item's children.  Key corresponds to the test item ID.
   testItemWatchers: Map<string, vscode.FileSystemWatcher>
+  knownFiles: Set<string>
+  private targetIdentifiers: Map<string, vscode.TestItem>
 
   constructor() {
     this.testCaseMetadata = new WeakMap<vscode.TestItem, TestCaseInfo>()
     this.testItemWatchers = new Map()
+    this.targetIdentifiers = new Map<string, vscode.TestItem>()
+    this.knownFiles = new Set<string>()
   }
 
   onModuleInit() {
@@ -58,5 +63,24 @@ export class TestCaseStore implements OnModuleInit, vscode.Disposable {
       })
     }
     clear(parentTest)
+  }
+
+  setTargetIdentifier(
+    targetIdentifier: BuildTargetIdentifier,
+    item: vscode.TestItem
+  ) {
+    const key = JSON.stringify(targetIdentifier)
+    this.targetIdentifiers.set(key, item)
+  }
+
+  getTargetIdentifier(
+    targetIdentifier: BuildTargetIdentifier
+  ): vscode.TestItem | undefined {
+    const key = JSON.stringify(targetIdentifier)
+    return this.targetIdentifiers.get(key)
+  }
+
+  clearTargetIdentifiers() {
+    this.targetIdentifiers.clear()
   }
 }

--- a/src/test/suite/language-tools/base.test.ts
+++ b/src/test/suite/language-tools/base.test.ts
@@ -30,7 +30,7 @@ suite('Base Language Tools', () => {
       vscode.Uri.parse('file:///repo/root/sample/my_test.py'),
       '/repo/root/'
     )
-    assert.strictEqual(result.isTestFile, true)
+    assert.strictEqual(result.isTestFile, false)
     assert.strictEqual(result.testCases.length, 0)
   })
 

--- a/src/test/suite/language-tools/manager.test.ts
+++ b/src/test/suite/language-tools/manager.test.ts
@@ -52,4 +52,25 @@ suite('Language Tools Manager', () => {
     const result = languageTools.getLanguageTools(target)
     assert.strictEqual(result.constructor.name, 'BaseLanguageTools')
   })
+
+  test('get tools for file, python', async () => {
+    const result = languageTools.getLanguageToolsForFile({
+      languageId: 'python',
+    } as any)
+    assert.strictEqual(result.constructor.name, 'PythonLanguageTools')
+  })
+
+  test('get tools for file, java', async () => {
+    const result = languageTools.getLanguageToolsForFile({
+      languageId: 'java',
+    } as any)
+    assert.strictEqual(result.constructor.name, 'JavaLanguageTools')
+  })
+
+  test('get tools for file, other', async () => {
+    const result = languageTools.getLanguageToolsForFile({
+      languageId: 'other',
+    } as any)
+    assert.strictEqual(result.constructor.name, 'BaseLanguageTools')
+  })
 })

--- a/src/test/suite/store.test.ts
+++ b/src/test/suite/store.test.ts
@@ -19,6 +19,7 @@ import {TestItemFactory} from '../../test-info/test-item-factory'
 import {CoverageTracker} from '../../coverage-utils/coverage-tracker'
 import {LanguageToolManager} from '../../language-tools/manager'
 import sinon from 'sinon'
+import {BuildTargetIdentifier} from 'src/bsp/bsp'
 
 suite('Test Controller', () => {
   let ctx: vscode.ExtensionContext
@@ -140,5 +141,25 @@ suite('Test Controller', () => {
     for (const spy of disposeSpies) {
       assert.ok(spy.called)
     }
+  })
+
+  test('store target identifiers', async () => {
+    await testCaseStore.onModuleInit()
+
+    const item = testCaseStore.testController.createTestItem('test', '')
+    const targetIdentifier: BuildTargetIdentifier = {
+      uri: 'file:///path/to/test',
+    }
+    testCaseStore.setTargetIdentifier(targetIdentifier, item)
+    assert.strictEqual(
+      testCaseStore.getTargetIdentifier(targetIdentifier),
+      item
+    )
+
+    testCaseStore.clearTargetIdentifiers()
+    assert.strictEqual(
+      testCaseStore.getTargetIdentifier(targetIdentifier),
+      undefined
+    )
   })
 })

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -8,6 +8,7 @@ export enum SettingName {
   BSP_SERVER_VERSION = 'serverVersion',
   BAZEL_BINARY_PATH = 'bazelBinaryPath',
   SERVER_INSTALL_MODE = 'serverInstallMode',
+  AUTO_EXPAND_TARGET = 'autoExpandTarget',
 }
 
 export interface SettingTypes {
@@ -16,6 +17,7 @@ export interface SettingTypes {
   [SettingName.BSP_SERVER_VERSION]: string
   [SettingName.BAZEL_BINARY_PATH]: string
   [SettingName.SERVER_INSTALL_MODE]: string
+  [SettingName.AUTO_EXPAND_TARGET]: boolean
 }
 
 export function getExtensionSetting<T extends keyof SettingTypes>(


### PR DESCRIPTION
Adds support to discover targets based on a user's open files, allowing test cases in a file to be resolved even if the user hasn't specifically expanded the target in the Test Explorer tree.

During the sync process, we will now check a user's open files.  If any are determined to be test files, we request the file's target from the BSP server, then resolve the test cases in that target.  After this is complete, the user will be able to run tests in those files via run arrows, without first having to navigate to the test explorer tree.  This is opt out via settings, as it does result in additional back and forth with the BSP server.

As a follow-up, I plan to add an inlay hint or other info to help the user update their scope if we try to find the target.