### PR TITLE
Add debug support in Test Explorer

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,6 +79,23 @@
           "type": "boolean",
           "default": "true",
           "description": "Find all tests within open files, without waiting for the file's target to be expanded in the Test Explorer."
+        },
+        "bazelbsp.debug.enabled": {
+          "type": "boolean",
+          "default": "false",
+          "markdownDescription": "Enable debugging integration in the Test Explorer.  This adds an additional Debug run profile for each test item.\nSet the bazelFlags, profileName, and readyPattern settings in this section to match your repo's required behavior."
+        },
+        "bazelbsp.debug.bazelFlags": {
+          "type": "array",
+          "description": "Flags to be added when debugging a target. Include any flags needed to ensure Bazel builds and runs the target in debug mode."
+        },
+        "bazelbsp.debug.readyPattern": {
+          "type": "string",
+          "description": "Regex pattern in the console output that signals that the target is ready for a debugger to connect. Once this is seen, the configured launch configuration will be triggered."
+        },
+        "bazelbsp.debug.launchConfigName": {
+          "type": "string",
+          "description": "Name of launch configuration that will be executed to begin the DAP debugging session. This must be a valid launch configuration in the launch.json file, workspace, or contributed by another extension."
         }
       }
     }

--- a/src/bsp/bsp-ext.ts
+++ b/src/bsp/bsp-ext.ts
@@ -19,6 +19,7 @@ export namespace TestParamsDataKind {
 export interface BazelTestParamsData {
   coverage?: boolean
   testFilter?: string
+  additionalBazelParams?: string
 }
 
 export namespace OnBuildPublishOutput {

--- a/src/test-info/test-info.ts
+++ b/src/test-info/test-info.ts
@@ -4,6 +4,7 @@ import {BuildTarget, TestParams, TestResult, StatusCode} from '../bsp/bsp'
 import {TestParamsDataKind, BazelTestParamsData} from '../bsp/bsp-ext'
 import {TestCaseStatus, TestRunTracker} from '../test-runner/run-tracker'
 import {DocumentTestItem, LanguageToolManager} from '../language-tools/manager'
+import {getExtensionSetting, SettingName} from '../utils/settings'
 
 export enum TestItemType {
   Root,
@@ -113,6 +114,16 @@ export class BuildTargetTestCaseInfo extends TestCaseInfo {
       coverage:
         currentRun.getRunProfileKind() === vscode.TestRunProfileKind.Coverage,
     }
+
+    // Includes additional debug-specific flags when necessary.
+    if (currentRun.getRunProfileKind() === vscode.TestRunProfileKind.Debug) {
+      const configuredFlags = currentRun.getDebugBazelFlags()
+      if (configuredFlags && configuredFlags.length > 0) {
+        // Bazel BSP accepts whitespace separated list of flags.
+        bazelParams.additionalBazelParams = configuredFlags.join(' ')
+      }
+    }
+
     const params = {
       targets: [this.target.id],
       originId: currentRun.originName,

--- a/src/test-runner/runner.ts
+++ b/src/test-runner/runner.ts
@@ -11,6 +11,7 @@ import {MessageConnection} from 'vscode-jsonrpc'
 import {TestRunTracker} from './run-tracker'
 import {RunTrackerFactory} from './run-factory'
 import {CoverageTracker} from '../coverage-utils/coverage-tracker'
+import {getExtensionSetting, SettingName} from '../utils/settings'
 
 @Injectable()
 export class TestRunner implements OnModuleInit, vscode.Disposable {
@@ -53,6 +54,17 @@ export class TestRunner implements OnModuleInit, vscode.Disposable {
     this.runProfiles.set(vscode.TestRunProfileKind.Coverage, coverageRunProfile)
     coverageRunProfile.loadDetailedCoverage =
       this.coverageTracker.loadDetailedCoverage.bind(this.coverageTracker)
+
+    // Debug run profile, added only when enabled.
+    if (getExtensionSetting(SettingName.DEBUG_ENABLED)) {
+      const debugRunProfile =
+        this.testCaseStore.testController.createRunProfile(
+          'Run with Debug',
+          vscode.TestRunProfileKind.Debug,
+          this.runHandler.bind(this)
+        )
+      this.runProfiles.set(vscode.TestRunProfileKind.Debug, debugRunProfile)
+    }
   }
 
   private async runHandler(

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -9,6 +9,10 @@ export enum SettingName {
   BAZEL_BINARY_PATH = 'bazelBinaryPath',
   SERVER_INSTALL_MODE = 'serverInstallMode',
   AUTO_EXPAND_TARGET = 'autoExpandTarget',
+  DEBUG_ENABLED = 'debug.enabled',
+  DEBUG_BAZEL_FLAGS = 'debug.bazelFlags',
+  LAUNCH_CONFIG_NAME = 'debug.launchConfigName',
+  DEBUG_READY_PATTERN = 'debug.readyPattern',
 }
 
 export interface SettingTypes {
@@ -18,6 +22,10 @@ export interface SettingTypes {
   [SettingName.BAZEL_BINARY_PATH]: string
   [SettingName.SERVER_INSTALL_MODE]: string
   [SettingName.AUTO_EXPAND_TARGET]: boolean
+  [SettingName.DEBUG_ENABLED]: boolean
+  [SettingName.DEBUG_BAZEL_FLAGS]: string[]
+  [SettingName.LAUNCH_CONFIG_NAME]: string
+  [SettingName.DEBUG_READY_PATTERN]: string
 }
 
 export function getExtensionSetting<T extends keyof SettingTypes>(


### PR DESCRIPTION
Add debug support to the test explorer.

When this feature is enabled (via `bazelbsp.debug.enabled` setting), an additional debug run option will appear on each test item.

Overall flow:
- When a debug button for a test case is clicked, run is trigged as usual, with added `additionalBazelParams` (now supported by bazel-bsp server).  These flags are configurable based on `bazelbsp.debug.bazelFlags` and should include any flags needed to get Bazel to build and launch the target in debug mode.
- As the build runs, messages are watched for a debug ready message.  The pattern to watch for is configurable in  `bazelbsp.debug.readyPattern`.
- Finally, once the pattern is matched, the VS Code launch configuration is triggered.  This allows use of an existing launch configuration in the workspace (which can be set via settings, workspace, launch.json, etc), configurable via `bazelbsp.debug.launchConfigName`.

If any of the settings are not properly set, the run will still attempt to proceed but print a warning in the output.