### PR TITLE
bazel-bsp server auto-update based on configured version

### DIFF
--- a/src/server/install.ts
+++ b/src/server/install.ts
@@ -166,7 +166,7 @@ export class BazelBSPInstaller {
       .join(' ')
 
     // Full install command including flags.
-    const installCommand = `"${coursierPath}" launch --jvm 11+ ${MAVEN_PACKAGE}:${config.serverVersion} -M ${INSTALL_METHOD} -- ${flagsString}`
+    const installCommand = `"${coursierPath}" launch --jvm openjdk:1.17.0 ${MAVEN_PACKAGE}:${config.serverVersion} -M ${INSTALL_METHOD} -- ${flagsString}`
 
     // Report progress in output channel.
     const installProcess = cp.spawn(installCommand, {cwd: root, shell: true})

--- a/src/server/server-manager.ts
+++ b/src/server/server-manager.ts
@@ -11,6 +11,7 @@ import {ConnectionDetailsParser} from './connection-details'
 import {Utils} from '../utils/utils'
 import {INSTALL_BSP_COMMAND} from './install'
 import {BspConnectionDetails} from '../bsp/bsp'
+import {getExtensionSetting, SettingName} from '../utils/settings'
 
 export const CANCEL_ERROR_CODE = -32603
 const SERVER_NAME = 'bazelbsp'
@@ -96,8 +97,10 @@ export class BuildServerManager implements vscode.Disposable, OnModuleInit {
         SERVER_NAME,
         rootDir
       )
-
-    if (connDetails) {
+    const configuredVersion = getExtensionSetting(
+      SettingName.BSP_SERVER_VERSION
+    )
+    if (connDetails && connDetails?.version === configuredVersion) {
       return connDetails
     }
 

--- a/src/test/suite/install.test.ts
+++ b/src/test/suite/install.test.ts
@@ -87,7 +87,7 @@ suite('BSP Installer', () => {
 
     // Just confirm that coursier path was part of the spawn call, to leave flexibility for other changes to the command.
     assert.ok(spawnStub.getCalls()[0].args[0].includes(coursierPath))
-    assert.ok(spawnStub.getCalls()[0].args[0].includes('--jvm 11+'))
+    assert.ok(spawnStub.getCalls()[0].args[0].includes('--jvm openjdk:1.17.0'))
     assert.ok(installResult)
   })
 


### PR DESCRIPTION
Add a version check during the server initialization process.  When the installed version does not match what is configured in VS Code settings (`bazelbsp.serverVersion`), the installer will be run to get the required version.  This will ensure that a user's installed bazel-bsp version stays in sync with the version expected by this extension.

Also update jdk version used by Coursier as newer versions of bazel-bsp require Java 17+, to get this working.  As a follow-up we can add in some additional logic here to depend on system Java where its version is new enough.