### PR TITLE
Update bazel-bsp default version

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         },
         "bazelbsp.serverVersion": {
           "type": "string",
-          "default": "3.2.0-20240606-167e699-NIGHTLY",
+          "default": "3.2.0-20250106-a42f8bf24-NIGHTLY",
           "description": "Version of the Bazel BSP server to install."
         },
         "bazelbsp.bazelBinaryPath": {

--- a/src/bsp/bsp-ext.ts
+++ b/src/bsp/bsp-ext.ts
@@ -70,3 +70,19 @@ export interface JUnitStyleTestCaseData {
   fullError?: string
   errorType?: string
 }
+
+export interface InitializeBuildData {
+  clientClassesRootDir?: string
+  openTelemetryEndpoint?: string
+  featureFlags?: FeatureFlags
+}
+
+export interface FeatureFlags {
+  isPythonSupportEnabled?: boolean
+  isAndroidSupportEnabled?: boolean
+  isGoSupportEnabled?: boolean
+  isRustSupportEnabled?: boolean
+  isPropagateExportsFromDepsEnabled?: boolean
+  /** Bazel specific */
+  bazelSymlinksScanMaxDepth?: number
+}

--- a/src/test-explorer/client.ts
+++ b/src/test-explorer/client.ts
@@ -198,6 +198,11 @@ export class BazelBSPBuildClient
     // Send initialize request to the server.
     try {
       const rootUri = Utils.getWorkspaceRoot()
+      const initData: bspExt.InitializeBuildData = {
+        featureFlags: {
+          isPythonSupportEnabled: true,
+        },
+      }
       const initResult = await conn.sendRequest(bsp.BuildInitialize.type, {
         displayName: 'VS Code Bazel BSP',
         version: pkg.version,
@@ -206,6 +211,7 @@ export class BazelBSPBuildClient
         capabilities: {
           languageIds: SUPPORTED_LANGUAGES,
         },
+        data: initData,
       })
 
       // Notify the build server that client initialization is complete.

--- a/src/test/suite/client.test.ts
+++ b/src/test/suite/client.test.ts
@@ -105,6 +105,11 @@ suite('Build Client', () => {
     assert.ok(initRequest.args[1].capabilities)
     assert.ok(initRequest.args[1].rootUri)
     assert.ok(initRequest.args[1].version)
+    assert.deepStrictEqual(initRequest.args[1].data, {
+      featureFlags: {
+        isPythonSupportEnabled: true,
+      },
+    })
 
     // Check that initialization result has been sent to the server.
     assert.equal(initNotificationStub.callCount, 1)


### PR DESCRIPTION
Updates the default bazel-bsp server version that gets installed by this extension.  There is also a new feature flags data field in the initialization request that needs to be set here (currently only Python is behind a flag, Java is always enabled).

This version is necessary to support newly added debug support via the test explorer.  With the newly added changes in https://github.com/uber/vscode-bazel-bsp/pull/30, users that have a different version than the one specified will be auto-updated to the matching version.

Verified core extension workflows with this version:
- Syncing test targets
- Run with/without coverage
- Run with debug