### PR TITLE
Update test results without depending on data from parent test task

### DIFF
--- a/src/test/suite/run-tracker.test.ts
+++ b/src/test/suite/run-tracker.test.ts
@@ -350,13 +350,13 @@ suite('Test Run Tracker', () => {
       {
         start: {
           originId: 'sample',
-          taskId: {id: 'task2', parents: ['task1']},
+          taskId: {id: 'task2', parents: []},
           message: 'task1 started',
           dataKind: TaskStartDataKind.TestStart,
         },
         finish: {
           originId: 'sample',
-          taskId: {id: 'task2', parents: ['task1']},
+          taskId: {id: 'task2', parents: []},
           status: StatusCode.Ok,
           message: 'task2 finished',
           dataKind: TaskFinishDataKind.TestFinish,
@@ -375,13 +375,13 @@ suite('Test Run Tracker', () => {
       {
         start: {
           originId: 'sample',
-          taskId: {id: 'task3', parents: ['task1']},
+          taskId: {id: 'task3', parents: []},
           message: 'task3 started',
           dataKind: TaskStartDataKind.TestStart,
         },
         finish: {
           originId: 'sample',
-          taskId: {id: 'task3', parents: ['task1']},
+          taskId: {id: 'task3', parents: []},
           status: StatusCode.Ok,
           message: 'task3 finished',
           dataKind: TaskFinishDataKind.TestFinish,


### PR DESCRIPTION
Recent changes within the bazel-bsp are resulting in blank parent ID/build target ID values for test case results.  Issue has been documented here (https://youtrack.jetbrains.com/issue/BAZEL-1585) and is prioritized for this release cycle.

This extension currently depends on those fields to update pass/fail status for individual test cases.

In order to unblock updating this extension to the latest bazel-bsp version, this PR includes a workaround to look for the test case under each target in the run.  Since this is less explicit than the prior approach, there is potential for collisions if the same test case appears in multiple targets in the same run.  However, this is not a typical expected scenario that users are likely to face in our setup, so we can proceed with this temporarily for now and revert to the prior approach once the upstream issue has been addressed.