### PR TITLE
Use namespaced package name in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "vscode-bazel-bsp",
+  "name": "@uber/vscode-bazel-bsp",
   "displayName": "Bazel Build Server Protocol (BSP)",
   "description": "Bazel BSP integration for VS Code.",
   "publisher": "Uber",
@@ -101,7 +101,7 @@
     }
   },
   "scripts": {
-    "package": "vsce package --yarn",
+    "package": "cp package.json package.bkp.json && jq '.name=\"vscode-bazel-bsp\"' package.bkp.json > package.json && vsce package --yarn && mv package.bkp.json package.json",
     "vscode:prepublish": "npm run esbuild-base -- --minify",
     "compile": "yarn run esbuild-base -- --sourcemap",
     "test-compile": "tsc -p ./",


### PR DESCRIPTION
For improved security, include a namespace in the package name.  This helps address a potential vulnerability if a user were to attempt to install an npm package with this same name, which to date we have not been using.

Since the vsce tool does not support namespaces in the package name, we also have to update the package command to temporarily remove then replace the namespace during this step.