### PR TITLE
Handle undefined result from executeDocumentSymbolProvider

### DIFF
--- a/src/language-tools/python.ts
+++ b/src/language-tools/python.ts
@@ -97,7 +97,7 @@ export class PythonLanguageTools
     }
 
     // Document symbols provided by Pylance.
-    const symbols: vscode.DocumentSymbol[] =
+    const symbols: vscode.DocumentSymbol[] | undefined =
       await vscode.commands.executeCommand(
         'vscode.executeDocumentSymbolProvider',
         document
@@ -161,8 +161,10 @@ export class PythonLanguageTools
     }
 
     // Start at top level and evaluate each symbol in the document.
-    for (const symbol of symbols) {
-      evaluateCurrentSymbol(symbol)
+    if (symbols) {
+      for (const symbol of symbols) {
+        evaluateCurrentSymbol(symbol)
+      }
     }
 
     const finalTestCases = result.filter(item => {

--- a/src/test/suite/language-tools/python.test.ts
+++ b/src/test/suite/language-tools/python.test.ts
@@ -78,6 +78,16 @@ suite('Python Language Tools', () => {
     assert.equal(result.documentTest?.name, 'my_test.py')
   })
 
+  test('undefined symbols', async () => {
+    executeCommandStub.resolves(undefined)
+    const result = await languageTools.getDocumentTestCases(
+      vscode.Uri.parse('file:///repo/root/sample/my_test.py'),
+      '/repo/root/'
+    )
+    assert.strictEqual(result.isTestFile, true)
+    assert.strictEqual(result.testCases.length, 0)
+  })
+
   test('non test file', async () => {
     const result = await languageTools.getDocumentTestCases(
       vscode.Uri.parse('file:///repo/root/sample/my_file.py'),


### PR DESCRIPTION
When resolving test symbols in a document, it's possible that there are situations where the call to get document symbols will return undefined (mainly if language server is still activating).  This was resulting in an uncaught exception that causes the loading to appear "stuck" on the UI.  This adds correct handling if this result is undefined.