### PR TITLE
Add project targets button and adjust default template

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
       },
       {
         "command": "bazelbsp.openProjectView",
-        "title": "Bazel BSP: Open Project View File"
+        "title": "Bazel BSP: Open Project View File",
+        "shortTitle": "Select Project Targets"
       }
     ],
     "configuration": {
@@ -98,6 +99,15 @@
           "description": "Name of launch configuration that will be executed to begin the DAP debugging session. This must be a valid launch configuration in the launch.json file, workspace, or contributed by another extension."
         }
       }
+    },
+    "menus": {
+      "view/title": [
+        {
+          "command": "bazelbsp.openProjectView",
+          "when": "view == 'workbench.view.testing'",
+          "group": "navigation"
+        }
+      ]
     }
   },
   "scripts": {

--- a/src/server/install.ts
+++ b/src/server/install.ts
@@ -159,7 +159,7 @@ export class BazelBSPInstaller {
       // Set Bazel project details to be used if a project file is not already present.
       ['--project-view-file', config.bazelProjectFilePath],
       ['--bazel-binary', bazelPath],
-      ['--targets', '# //YOUR_TARGETS/...'],
+      ['--targets', '//your/targets/here/...'],
     ])
     const flagsString = Array.from(installFlags.entries())
       .map(([key, value]) => `${key} "${value}"`)


### PR DESCRIPTION
Add a button at the top of the testing panel to make it easier for users to jump directly to the project view file.

Also, adjust the format of the sample targets that get added - the prior format attempted to show it as a comment but it just came out looking like `    @# //YOUR_TARGETS/...` which is a bit confusing.