### PR TITLE
Include additional options in install command

### DIFF
--- a/src/server/install.ts
+++ b/src/server/install.ts
@@ -186,14 +186,22 @@ export class BazelBSPInstaller {
       ['--bazel-binary', bazelPath],
       ['--targets', '//your/targets/here/...'],
     ])
+
     const flagsString = Array.from(installFlags.entries())
       .map(([key, value]) => `${key} "${value}"`)
       .join(' ')
+    const additionalInstallFlags = getExtensionSetting(
+      SettingName.ADDITIONAL_INSTALL_FLAGS
+    )
+    const additionalInstallFlagsString = additionalInstallFlags
+      ? additionalInstallFlags.join(' ')
+      : ''
 
     const javaVersion =
       os.platform() === 'darwin' ? TEMURIN_JAVA_17 : OPEN_JDK_JAVA_17
     this.outputChannel.appendLine(`Using Java version: ${javaVersion}`)
-    const installCommand = `"${coursierPath}" launch --jvm ${javaVersion} ${MAVEN_PACKAGE}:${config.serverVersion} -M ${INSTALL_METHOD} -- ${flagsString}`
+    const installCommand = `"${coursierPath}" launch --jvm ${javaVersion} ${MAVEN_PACKAGE}:${config.serverVersion} -M ${INSTALL_METHOD} ${additionalInstallFlagsString} -- ${flagsString}`
+    this.outputChannel.appendLine(`Running command: ${installCommand}`)
 
     // Report progress in output channel.
     const installProcess = cp.spawn(installCommand, {cwd: root, shell: true})

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -13,6 +13,7 @@ export enum SettingName {
   DEBUG_BAZEL_FLAGS = 'debug.bazelFlags',
   LAUNCH_CONFIG_NAME = 'debug.launchConfigName',
   DEBUG_READY_PATTERN = 'debug.readyPattern',
+  ADDITIONAL_INSTALL_FLAGS = 'additionalInstallFlags',
 }
 
 export interface SettingTypes {
@@ -26,6 +27,7 @@ export interface SettingTypes {
   [SettingName.DEBUG_BAZEL_FLAGS]: string[]
   [SettingName.LAUNCH_CONFIG_NAME]: string
   [SettingName.DEBUG_READY_PATTERN]: string
+  [SettingName.ADDITIONAL_INSTALL_FLAGS]: string[]
 }
 
 export function getExtensionSetting<T extends keyof SettingTypes>(


### PR DESCRIPTION
To be able to bypass the SSL exception during bsp server installation we need to be able to 
pass on additional flags to coursier launch command.

Here we are adding option to add additional flags for install command.

Additionally cleaned up the code and removed ununsed declarations and imports


**Test**
- Unit Test 
- Tested regular installation on local no issues