### PR TITLE
Launch debugging session once only during test debug

### DIFF
--- a/src/test-runner/run-tracker.ts
+++ b/src/test-runner/run-tracker.ts
@@ -71,6 +71,7 @@ export class TestRunTracker implements TaskOriginHandlers {
   private pending: Thenable<void>[] = []
   private buildTaskTracker: TaskEventTracker = new TaskEventTracker()
   private debugInfo: DebugInfo | undefined
+  private hasDebugSessionBeenInitiated = false
 
   constructor(params: RunTrackerParams) {
     this.allTests = new Map<TestItemType, TestCaseInfo[]>()
@@ -235,8 +236,10 @@ export class TestRunTracker implements TaskOriginHandlers {
     // If the message matches the configured pattern, start the debug session.
     if (
       this.debugInfo?.launchConfig &&
-      this.debugInfo.readyPattern?.test(params.message)
+      this.debugInfo.readyPattern?.test(params.message) &&
+      !this.hasDebugSessionBeenInitiated
     ) {
+      this.hasDebugSessionBeenInitiated = true
       this.run.appendOutput(
         `Starting remote debug session [Launch config: '${this.debugInfo.launchConfig.name}']\r\n`
       )


### PR DESCRIPTION
When debugging test in vscode we saw while hitting disconnect/stop, debug sessions are respawned. This should not be happening. 

Here we enhance the TestRunTracker to ensure that the debug session starts only on the first match of the configured ready pattern. 
Introduced a flag to track if the debug session has already been initiated, preventing multiple starts from subsequent matches. 

For Java:
Ready patterns `Listening for transport dt_socket at address` are printed multiple times  in java debug session due to how custom test runners are handling tests.


Test
- Unit Test 
- Ensured with this change we are not seeing multiple debug session launches on disconnect/ stops