### PR TITLE
Adjust test class regex

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Bazel Build Server Protocol (BSP)",
   "description": "Bazel BSP integration for VS Code.",
   "publisher": "Uber",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "license": "Apache-2.0",
   "repository": "https://github.com/uber/vscode-bazel-bsp",
   "engines": {

--- a/src/language-tools/java.ts
+++ b/src/language-tools/java.ts
@@ -8,7 +8,7 @@ import {SourceFileTestCaseInfo, TestCaseInfo} from '../test-info/test-info'
 
 const TEST_FILE_REGEX = /^(Test.+\.java|.+Test\.java)$/
 const JAVA_TEST_REGEX =
-  /@Test\s+.*\s+public void (?<methodName>\w+)|public class (?<className>(Test\w*|\w+Test))\s+extends/
+  /@Test\s+.*\s+public void (?<methodName>\w+)|public class (?<className>(Test\w*|\w+Test))\s+/
 const PACKAGE_NAME_REGEX =
   /package\s+(?<packageName>([a-zA-Z_][a-zA-Z0-9_]*)(\.[a-zA-Z_][a-zA-Z0-9_]*)*);/
 const PARAMETERIZED_TEST_REGEX = /^(?<lookupKey>.*?)(?=\[.*?\])(.*)$/

--- a/src/test/suite/language-tools/java.test.ts
+++ b/src/test/suite/language-tools/java.test.ts
@@ -83,7 +83,7 @@ suite('Java Language Tools', () => {
   test('no matching test class name', async () => {
     const result = await languageTools.getDocumentTestCases(
       vscode.Uri.file(
-        path.join(fixtureDir, 'language_files', 'SampleInvalidTest.java')
+        path.join(fixtureDir, 'language_files', 'SampleNonTestClass.java')
       )
     )
 

--- a/src/test/testdata/language_files/SampleNonTestClass.java
+++ b/src/test/testdata/language_files/SampleNonTestClass.java
@@ -6,7 +6,7 @@ import static org.junit.Assert.assertNotNull;
 import com.uber.testing.base.TestBase;
 import org.junit.Test;
 
-public class SampleValidExampleTest {
+public class SampleNonTestClass {
   @Test
   public void testGetInstance() {
     SampleClientProvider instance =


### PR DESCRIPTION
Adjust regex to support test classes that do not contain an extends keyword.

Also bump version.