### PR TITLE
Allow non public class and methods for tests

### DIFF
--- a/src/language-tools/java.ts
+++ b/src/language-tools/java.ts
@@ -8,7 +8,7 @@ import {SourceFileTestCaseInfo, TestCaseInfo} from '../test-info/test-info'
 
 const TEST_FILE_REGEX = /^(Test.+\.java|.+Test\.java)$/
 const JAVA_TEST_REGEX =
-  /@Test\s+.*\s+public void (?<methodName>\w+)|public class (?<className>(Test\w*|\w+Test))\s+/
+  /@Test\s+.*\s+void (?<methodName>\w+)|class (?<className>(Test\w*|\w+Test))\s+/
 const PACKAGE_NAME_REGEX =
   /package\s+(?<packageName>([a-zA-Z_][a-zA-Z0-9_]*)(\.[a-zA-Z_][a-zA-Z0-9_]*)*);/
 const PARAMETERIZED_TEST_REGEX = /^(?<lookupKey>.*?)(?=\[.*?\])(.*)$/

--- a/src/test/suite/language-tools/java.test.ts
+++ b/src/test/suite/language-tools/java.test.ts
@@ -80,6 +80,29 @@ suite('Java Language Tools', () => {
     assert.equal(result.documentTest?.name, 'TestSampleValidExample')
   })
 
+  test('process test cases, junit 5', async () => {
+    const result = await languageTools.getDocumentTestCases(
+      vscode.Uri.file(
+        path.join(fixtureDir, 'language_files', 'TestSampleJUnit5.java')
+      )
+    )
+
+    assert.strictEqual(result.isTestFile, true)
+    assert.strictEqual(result.testCases.length, 2)
+
+    const expectedBaseTestFilter =
+      'com.sample.project.common.client.samplepackage.TestSampleJUnit5'
+
+    const expectedTests = ['testCase1', 'testCase2']
+    for (const test of result.testCases) {
+      assert.ok(expectedTests.includes(test.name))
+      assert.ok(test.testFilter.startsWith(expectedBaseTestFilter))
+      assert.ok(test.testFilter.endsWith(test.name))
+    }
+    assert.equal(result.documentTest?.testFilter, expectedBaseTestFilter)
+    assert.equal(result.documentTest?.name, 'TestSampleJUnit5')
+  })
+
   test('no matching test class name', async () => {
     const result = await languageTools.getDocumentTestCases(
       vscode.Uri.file(

--- a/src/test/testdata/language_files/TestSampleJUnit5.java
+++ b/src/test/testdata/language_files/TestSampleJUnit5.java
@@ -1,0 +1,26 @@
+package com.sample.project.common.client.samplepackage;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import com.uber.testing.base.TestBase;
+import org.junit.Test;
+
+class TestSampleJUnit5 {
+  @Test
+  void testCase1() {
+    SampleClientProvider instance =
+        SampleClientProvider.getInstance("sample");
+    assertNotNull(instance);
+  }
+
+  @Test
+  void testCase2() {
+    SampleClientProvider instance =
+        SampleClientProvider.getInstance("sample");
+    StatementRenderingClient clientA = instance.getSampleClient();
+    StatementRenderingClient clientB = instance.getSampleClient();
+    assertNotNull(clientA);
+    assertEquals(clientA, clientB);
+  }
+}


### PR DESCRIPTION
User feedback that with JUnit5 migration, there cases where the test class and method names are no longer public, which is not required for JUnit5.  Update the regex here to support this case so that these tests will be discovered as well.