### PR TITLE
Add ideClient tag via additional bazel params

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ dist
 .DS_Store
 .bazelbsp
 .bsp
+vscode-bazel-bsp-*.vsix

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Bazel Build Server Protocol (BSP)",
   "description": "Bazel BSP integration for VS Code.",
   "publisher": "Uber",
-  "version": "0.0.13-2",
+  "version": "0.0.14",
   "license": "Apache-2.0",
   "repository": "https://github.com/uber/vscode-bazel-bsp",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Bazel Build Server Protocol (BSP)",
   "description": "Bazel BSP integration for VS Code.",
   "publisher": "Uber",
-  "version": "0.0.13",
+  "version": "0.0.13-2",
   "license": "Apache-2.0",
   "repository": "https://github.com/uber/vscode-bazel-bsp",
   "engines": {

--- a/src/test-info/test-info.ts
+++ b/src/test-info/test-info.ts
@@ -124,6 +124,16 @@ export class BuildTargetTestCaseInfo extends TestCaseInfo {
       }
     }
 
+    // Add the IDE tag (--define flag) to additionalBazelParams
+    const ideTag = currentRun.getIdeTag()
+    if (ideTag && ideTag.trim().length > 0) {
+      if (bazelParams.additionalBazelParams) {
+        bazelParams.additionalBazelParams += ` ${ideTag}`
+      } else {
+        bazelParams.additionalBazelParams = ideTag
+      }
+    }
+
     const params = {
       targets: [this.target.id],
       originId: currentRun.originName,

--- a/src/test-info/test-info.ts
+++ b/src/test-info/test-info.ts
@@ -124,9 +124,9 @@ export class BuildTargetTestCaseInfo extends TestCaseInfo {
       }
     }
 
-    // Add the IDE tag (--define flag) to additionalBazelParams
+    // Additional Bazel params is not supported in BSP coverage for now
     const ideTag = currentRun.getIdeTag()
-    if (ideTag && ideTag.trim().length > 0) {
+    if (ideTag && !bazelParams.coverage) {
       if (bazelParams.additionalBazelParams) {
         bazelParams.additionalBazelParams += ` ${ideTag}`
       } else {

--- a/src/test-runner/run-factory.ts
+++ b/src/test-runner/run-factory.ts
@@ -7,6 +7,7 @@ import {TestRunTracker} from './run-tracker'
 import {BazelBSPBuildClient} from '../test-explorer/client'
 import {CoverageTracker} from '../coverage-utils/coverage-tracker'
 import {LanguageToolManager} from '../language-tools/manager'
+import {detectIdeClient} from '../utils/utils'
 
 @Injectable()
 export class RunTrackerFactory {
@@ -36,6 +37,9 @@ export class RunTrackerFactory {
       coverageTracker: this.coverageTracker,
       languageToolManager: this.languageToolManager,
     })
+
+    const ideClient = detectIdeClient()
+    requestTracker.setIdeTag(ideClient)
 
     this.buildClient.registerOriginHandlers(originId, requestTracker)
     requestTracker.onDone(() =>

--- a/src/test-runner/run-tracker.ts
+++ b/src/test-runner/run-tracker.ts
@@ -72,6 +72,7 @@ export class TestRunTracker implements TaskOriginHandlers {
   private buildTaskTracker: TaskEventTracker = new TaskEventTracker()
   private debugInfo: DebugInfo | undefined
   private hasDebugSessionBeenInitiated = false
+  private ideTag: string
 
   constructor(params: RunTrackerParams) {
     this.allTests = new Map<TestItemType, TestCaseInfo[]>()
@@ -83,6 +84,7 @@ export class TestRunTracker implements TaskOriginHandlers {
     this.cancelToken = params.cancelToken
     this.coverageTracker = params.coverageTracker
     this.languageToolManager = params.languageToolManager
+    this.ideTag = 'unknown'
 
     this.prepareCurrentRun()
     this.prepareDebugInfo()
@@ -490,6 +492,23 @@ export class TestRunTracker implements TaskOriginHandlers {
           formatTestResultMessage(testFinishData)
         )
     }
+  }
+
+  /**
+   * Set the IDE tag to be used for this test run
+   * @param ideClient IDE client identifier (e.g., 'vscode', 'cursor')
+   */
+  public setIdeTag(ideClient: string): void {
+    // Use Bazel's --define flag which is specifically designed for user-defined values
+    this.ideTag = `--define=ide_client=${ideClient}`
+  }
+
+  /**
+   * Get the IDE tag for this test run
+   * @returns The IDE client identifier
+   */
+  public getIdeTag(): string {
+    return this.ideTag
   }
 }
 

--- a/src/test-runner/run-tracker.ts
+++ b/src/test-runner/run-tracker.ts
@@ -500,7 +500,7 @@ export class TestRunTracker implements TaskOriginHandlers {
    */
   public setIdeTag(ideClient: string): void {
     // Use Bazel's --define flag which is specifically designed for user-defined values
-    this.ideTag = `--define=ide_client=${ideClient}`
+    this.ideTag = `--test_env=IDE_CLIENT=${ideClient}`
   }
 
   /**

--- a/src/test-runner/run-tracker.ts
+++ b/src/test-runner/run-tracker.ts
@@ -499,7 +499,7 @@ export class TestRunTracker implements TaskOriginHandlers {
    * @param ideClient IDE client identifier (e.g., 'vscode', 'cursor')
    */
   public setIdeTag(ideClient: string): void {
-    // Use Bazel's --define flag which is specifically designed for user-defined values
+    // use test_env to set the IDE_CLIENT environment variable
     this.ideTag = `--test_env=IDE_CLIENT=${ideClient}`
   }
 

--- a/src/test/suite/run-factory.test.ts
+++ b/src/test/suite/run-factory.test.ts
@@ -134,7 +134,7 @@ suite('Test Runner Factory', () => {
         sampleToken
       )
       assert.ok(detectIdeClientStub.calledOnce)
-      assert.equal(runTracker.getIdeTag(), '--define=ide_client=test-ide')
+      assert.equal(runTracker.getIdeTag(), '--test_env=IDE_CLIENT=test-ide')
     } finally {
       detectIdeClientStub.restore()
     }

--- a/src/test/suite/run-factory.test.ts
+++ b/src/test/suite/run-factory.test.ts
@@ -22,6 +22,7 @@ import {TestItemFactory} from '../../test-info/test-item-factory'
 import {CoverageTracker} from '../../coverage-utils/coverage-tracker'
 import {LanguageToolManager} from '../../language-tools/manager'
 import {SyncHintDecorationsManager} from '../../test-explorer/decorator'
+import * as utils from '../../utils/utils'
 
 suite('Test Runner Factory', () => {
   let ctx: vscode.ExtensionContext
@@ -116,5 +117,26 @@ suite('Test Runner Factory', () => {
     assert.equal(registerHandlersStub.firstCall.args[0], runTracker.originName)
     assert.equal(registerHandlersStub.firstCall.args[1], runTracker)
     assert.ok(disposeHandlersStub.calledOnce)
+  })
+
+  test('newRun sets IDE tag', async () => {
+    const detectIdeClientStub = sandbox.stub(utils, 'detectIdeClient')
+    detectIdeClientStub.returns('test-ide')
+
+    try {
+      const roots: vscode.TestItem[] = []
+      testCaseStore.testController.items.forEach(item => {
+        roots.push(item)
+      })
+      const sampleToken = new vscode.CancellationTokenSource().token
+      const runTracker = runFactory.newRun(
+        new vscode.TestRunRequest(Array.from(roots)),
+        sampleToken
+      )
+      assert.ok(detectIdeClientStub.calledOnce)
+      assert.equal(runTracker.getIdeTag(), '--define=ide_client=test-ide')
+    } finally {
+      detectIdeClientStub.restore()
+    }
   })
 })

--- a/src/test/suite/runner.test.ts
+++ b/src/test/suite/runner.test.ts
@@ -238,7 +238,7 @@ suite('Test Runner', () => {
       assert.ok(!callArgs[1].data.coverage)
       assert.strictEqual(
         callArgs[1].data.additionalBazelParams,
-        '--my_flag_1 --my_flag_2 --define=ide_client=cursor'
+        '--my_flag_1 --my_flag_2 --test_env=IDE_CLIENT=cursor'
       )
       assert.strictEqual(callArgs[1].dataKind, TestParamsDataKind.BazelTest)
     }

--- a/src/test/suite/runner.test.ts
+++ b/src/test/suite/runner.test.ts
@@ -31,6 +31,7 @@ import {CoverageTracker} from '../../coverage-utils/coverage-tracker'
 import {LanguageToolManager} from '../../language-tools/manager'
 import {SyncHintDecorationsManager} from '../../test-explorer/decorator'
 import * as settings from '../../utils/settings'
+import * as utils from '../../utils/utils'
 
 suite('Test Runner', () => {
   let ctx: vscode.ExtensionContext
@@ -207,6 +208,9 @@ suite('Test Runner', () => {
       .stub(sampleConn, 'sendRequest')
       .returns(Promise.resolve(sampleResult))
 
+    // Mock the IDE tag detection
+    sandbox.stub(utils, 'detectIdeClient').returns('cursor')
+
     // Ensure run profile creation.
     await testRunner.onModuleInit()
     const runProfile = testRunner.runProfiles.get(
@@ -234,7 +238,7 @@ suite('Test Runner', () => {
       assert.ok(!callArgs[1].data.coverage)
       assert.strictEqual(
         callArgs[1].data.additionalBazelParams,
-        '--my_flag_1 --my_flag_2'
+        '--my_flag_1 --my_flag_2 --define=ide_client=cursor'
       )
       assert.strictEqual(callArgs[1].dataKind, TestParamsDataKind.BazelTest)
     }

--- a/src/test/suite/test-info.test.ts
+++ b/src/test/suite/test-info.test.ts
@@ -198,6 +198,67 @@ suite('TestInfo', () => {
       const result = testInfo.prepareTestRunParams(currentRun)
       assert.equal(result, undefined)
     })
+
+    test('build target with IDE tag', async () => {
+      const testItem = testController.createTestItem('sample', 'sample')
+      const testInfo = new BuildTargetTestCaseInfo(testItem, sampleTarget)
+
+      // Test with IDE tag
+      const currentRun = sandbox.createStubInstance(TestRunTracker)
+      sandbox.stub(currentRun, 'originName').get(() => 'sample')
+      currentRun.getRunProfileKind.returns(vscode.TestRunProfileKind.Run)
+      currentRun.getIdeTag.returns('--define=ide_client=cursor')
+
+      const result = testInfo.prepareTestRunParams(currentRun)
+      assert.deepStrictEqual(result, {
+        arguments: [],
+        environmentVariables: {},
+        originId: 'sample',
+        targets: [
+          {
+            uri: '//sample/target:test',
+          },
+        ],
+        workingDirectory: '',
+        dataKind: TestParamsDataKind.BazelTest,
+        data: {
+          coverage: false,
+          additionalBazelParams: '--define=ide_client=cursor',
+        },
+      })
+    })
+
+    test('build target with IDE tag and debug flags', async () => {
+      const testItem = testController.createTestItem('sample', 'sample')
+      const testInfo = new BuildTargetTestCaseInfo(testItem, sampleTarget)
+
+      // Test with IDE tag and debug flags
+      const currentRunWithDebug = sandbox.createStubInstance(TestRunTracker)
+      sandbox.stub(currentRunWithDebug, 'originName').get(() => 'sample')
+      currentRunWithDebug.getRunProfileKind.returns(
+        vscode.TestRunProfileKind.Debug
+      )
+      currentRunWithDebug.getIdeTag.returns('--define=ide_client=vscode')
+      currentRunWithDebug.getDebugBazelFlags.returns(['--flag1', '--flag2'])
+
+      const resultWithDebug = testInfo.prepareTestRunParams(currentRunWithDebug)
+      assert.deepStrictEqual(resultWithDebug, {
+        arguments: [],
+        environmentVariables: {},
+        originId: 'sample',
+        targets: [
+          {
+            uri: '//sample/target:test',
+          },
+        ],
+        workingDirectory: '',
+        dataKind: TestParamsDataKind.BazelTest,
+        data: {
+          coverage: false,
+          additionalBazelParams: '--flag1 --flag2 --define=ide_client=vscode',
+        },
+      })
+    })
   })
 
   suite('Set display name', () => {

--- a/src/test/suite/test-info.test.ts
+++ b/src/test/suite/test-info.test.ts
@@ -207,7 +207,7 @@ suite('TestInfo', () => {
       const currentRun = sandbox.createStubInstance(TestRunTracker)
       sandbox.stub(currentRun, 'originName').get(() => 'sample')
       currentRun.getRunProfileKind.returns(vscode.TestRunProfileKind.Run)
-      currentRun.getIdeTag.returns('--define=ide_client=cursor')
+      currentRun.getIdeTag.returns('--test_env=IDE_CLIENT=cursor')
 
       const result = testInfo.prepareTestRunParams(currentRun)
       assert.deepStrictEqual(result, {
@@ -223,7 +223,7 @@ suite('TestInfo', () => {
         dataKind: TestParamsDataKind.BazelTest,
         data: {
           coverage: false,
-          additionalBazelParams: '--define=ide_client=cursor',
+          additionalBazelParams: '--test_env=IDE_CLIENT=cursor',
         },
       })
     })

--- a/src/test/suite/utils.test.ts
+++ b/src/test/suite/utils.test.ts
@@ -120,6 +120,70 @@ suite('Utils Test Suite', () => {
     }
   })
 
+  test('detectIdeClient', async () => {
+    const originalEnv = process.env
+
+    const testCases = [
+      {
+        env: {
+          PATH: '',
+          __CFBundleIdentifier: 'com.microsoft.VSCode',
+        },
+        expected: 'vscode',
+        name: 'VSCode via bundle ID 1',
+      },
+      {
+        env: {
+          PATH: '',
+          __CFBundleIdentifier: 'com.microsoft.VSCodeInsiders',
+        },
+        expected: 'vscode-insiders',
+        name: 'VSCode via bundle ID 2',
+      },
+      {
+        env: {
+          PATH: '/usr/bin:/path/to/.vscode/abc/remote-cli',
+          __CFBundleIdentifier: '',
+        },
+        expected: 'vscode',
+        name: 'VSCode via PATH 1',
+      },
+      {
+        env: {
+          PATH: '',
+          __CFBundleIdentifier: 'com.todesktop.230313mzl4w4u92',
+        },
+        expected: 'cursor',
+        name: 'Cursor via bundle ID 1',
+      },
+      {
+        env: {
+          PATH: '/usr/bin:/path/to/.cursor/abc/remote-cli',
+          __CFBundleIdentifier: '',
+        },
+        expected: 'cursor',
+        name: 'Cursor via PATH',
+      },
+      {
+        env: {
+          PATH: '/usr/bin:/bin:/usr/local/bin',
+          __CFBundleIdentifier: '',
+        },
+        expected: 'unknown',
+        name: 'Unknown IDE',
+      },
+    ]
+
+    for (const testCase of testCases) {
+      process.env = {...testCase.env}
+      const result = detectIdeClient()
+      assert.strictEqual(result, testCase.expected)
+    }
+
+    // Restore original environment
+    process.env = originalEnv
+  })
+
   test('detectIdeClient with different environments', async () => {
     const processEnv = process.env
 

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -104,3 +104,35 @@ export class Deferred<T> {
     })
   }
 }
+
+/**
+ * Detect which IDE client is being used.
+ * @returns {string} The detected IDE client identifier
+ */
+export function detectIdeClient(): string {
+  const path = process.env.PATH || ''
+  const cfBundleId = process.env.__CFBundleIdentifier || ''
+
+  // Cursor detection
+  if (
+    (path.includes('.cursor') && path.includes('remote-cli')) ||
+    cfBundleId === 'com.todesktop.230313mzl4w4u92'
+  ) {
+    return 'cursor'
+  }
+
+  // VS Code detection
+  if (
+    (path.includes('.vscode') && path.includes('remote-cli')) ||
+    cfBundleId === 'com.microsoft.VSCode'
+  ) {
+    return 'vscode'
+  }
+
+  // VS Code Insiders detection
+  if (cfBundleId === 'com.microsoft.VSCodeInsiders') {
+    return 'vscode-insiders'
+  }
+
+  return 'unknown'
+}


### PR DESCRIPTION
Here we add detectIdeClient utility function to identify which IDEClient the bsp client is running on.
By default we support cursor and vscode only for now but this  can be modified in future to accomodate more clients.

Here we are using bazel's [test env flag](https://bazel.build/reference/command-line-reference#flag--test_env) `--test_env=<ide>` to add ide client info.

Added test to verify the behaviour.

Coverage does not support additionalBazelParams once its supported we will enable this for coverage as well

IDE is identified by bundleidentifier on mac or path env variable which is when.

Added gitignore to ignore vsix output.
