### PR TITLE
Use VirtusLab distribution of bazel-bsp

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
         },
         "bazelbsp.serverVersion": {
           "type": "string",
-          "default": "3.2.0-20250106-a42f8bf24-NIGHTLY",
+          "default": "4.0.1",
           "description": "Version of the Bazel BSP server to install."
         },
         "bazelbsp.bazelBinaryPath": {

--- a/src/server/install.ts
+++ b/src/server/install.ts
@@ -18,7 +18,7 @@ import {
 
 export const INSTALL_BSP_COMMAND = 'bazelbsp.install'
 
-const MAVEN_PACKAGE = 'org.jetbrains.bsp:bazel-bsp'
+const MAVEN_PACKAGE = 'org.virtuslab:bazel-bsp'
 const INSTALL_METHOD = 'org.jetbrains.bsp.bazel.install.Install'
 const COURSIER_URL_DEFAULT = 'https://git.io/coursier-cli'
 const COURSIER_URL_APPLE_SILICON =

--- a/src/test/suite/install.test.ts
+++ b/src/test/suite/install.test.ts
@@ -163,7 +163,7 @@ load("//aspects:utils/utils.bzl", "create_struct", "file_location", "to_file_loc
       const spawnCall = spawnStub.getCalls()[0]
       assert.ok(spawnCall.args[0].includes(coursierPath))
       assert.ok(spawnCall.args[0].includes(`--jvm ${config.javaVersion}`))
-      assert.ok(spawnCall.args[0].includes('org.jetbrains.bsp:bazel-bsp:2.0.0'))
+      assert.ok(spawnCall.args[0].includes('org.virtuslab:bazel-bsp:2.0.0'))
       assert.deepStrictEqual(spawnCall.args[1], {
         cwd: '/repo/root',
         shell: true,


### PR DESCRIPTION
Updating this extension to transition from JetBrains BSP distribution to the new fork hosted on https://github.com/VirtusLab/bazel-bsp.  No major functional changes, except for added compatibility for non-Bzlmod repos on Bazel 8+ (https://github.com/VirtusLab/bazel-bsp/pull/21).

Tested the following commands on Java/Python monorepos:
- Run, Coverage, Debug for individual test cases
- Syncing targets