### PR TITLE
release version 0.0.15

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Bazel Build Server Protocol (BSP)",
   "description": "Bazel BSP integration for VS Code.",
   "publisher": "Uber",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "license": "Apache-2.0",
   "repository": "https://github.com/uber/vscode-bazel-bsp",
   "engines": {


### PR DESCRIPTION
Releasing version 0.0.15.

This includes the switch over to VertusLab BSP (https://github.com/VirtusLab/bazel-bsp).

Before releasing internally, we should perform additional validation to ensure existing features still work.