### PR TITLE
Fix unresolved child tests inheriting target failures

### DIFF
--- a/src/test-info/test-info.ts
+++ b/src/test-info/test-info.ts
@@ -164,8 +164,9 @@ export class BuildTargetTestCaseInfo extends TestCaseInfo {
       TestItemType.BazelTarget
     )) {
       if (result.statusCode === StatusCode.Error) {
-        // On error, mark children that didn't receive individual results as failed.
-        currentRun.updateStatus(child.testItem, TestCaseStatus.Failed)
+        // A target-level failure does not prove every discovered child test failed.
+        // Mark unknown children skipped so VS Code does not visually inherit the parent failure.
+        currentRun.updateStatus(child.testItem, TestCaseStatus.Skipped)
       } else {
         // On success, let Test Explorer determine status based on children's outcomes.
         currentRun.updateStatus(child.testItem, TestCaseStatus.Inherit)

--- a/src/test/suite/test-info.test.ts
+++ b/src/test/suite/test-info.test.ts
@@ -377,6 +377,17 @@ suite('TestInfo', () => {
 
     test('error result', async () => {
       const testInfo = new BuildTargetTestCaseInfo(testItem, sampleTarget)
+      const childItem = testController.createTestItem('child', 'child')
+      const childInfo = new TestCaseInfo(
+        childItem,
+        sampleTarget,
+        TestItemType.TestCase
+      )
+      currentRun.pendingChildrenIterator.returns(
+        (function* () {
+          yield childInfo
+        })()
+      )
       const bspResult: TestResult = {
         statusCode: StatusCode.Error,
         originId: 'sample',
@@ -395,6 +406,11 @@ suite('TestInfo', () => {
       assert.equal(
         currentRun.updateStatus.getCall(0).args[2]?.message,
         'hello\nworld'
+      )
+      assert.equal(currentRun.updateStatus.getCall(1).args[0], childItem)
+      assert.equal(
+        currentRun.updateStatus.getCall(1).args[1],
+        TestCaseStatus.Skipped
       )
     })
 


### PR DESCRIPTION
Summary:
- Prevent unresolved child test cases from being marked failed when only the parent Bazel target reports an aggregate failure.
- Mark pending child tests as skipped on target-level errors so VS Code does not visually propagate the parent failure to sibling leaf tests.
- Add regression coverage for target-level error handling.

Test Plan:
- ran test-compile command and unit tests
- packaged and installed a test VSIX in Cursor, reproduced a file with one intentionally failing Jest test, and verified sibling leaf tests no longer show as failed from the aggregate target failure.