### PR TITLE
Fix TypeScript project-level test runs

### DIFF
--- a/src/language-tools/base.ts
+++ b/src/language-tools/base.ts
@@ -2,7 +2,7 @@ import * as vscode from 'vscode'
 import {LanguageTools, TestFileContents} from './manager'
 import * as bsp from '../bsp/bsp'
 import {TestFinish} from '../bsp/bsp'
-import {TestCaseInfo} from '../test-info/test-info'
+import type {TestCaseInfo} from '../test-info/test-info'
 
 /**
  * Fallback implementation for languages that do not have their own specific logic built out.
@@ -23,6 +23,14 @@ export class BaseLanguageTools implements LanguageTools {
    * @returns undefined as there is no support for individual test case identification.
    */
   mapTestCaseInfoToLookupKey(testCaseInfo: TestCaseInfo): string | undefined {
+    return undefined
+  }
+
+  shouldDeferSourceDirectoryRun(): boolean {
+    return false
+  }
+
+  getTestFileArgument(uri: vscode.Uri | undefined): string | undefined {
     return undefined
   }
 

--- a/src/language-tools/manager.ts
+++ b/src/language-tools/manager.ts
@@ -7,7 +7,7 @@ import {PythonLanguageTools} from './python'
 import {BaseLanguageTools} from './base'
 import {JavaLanguageTools} from './java'
 import {TypeScriptLanguageTools} from './typescript'
-import {TestCaseInfo} from '../test-info/test-info'
+import type {TestCaseInfo} from '../test-info/test-info'
 
 /**
  * LanguageTools is used to define behavior that should differ based on language.
@@ -23,6 +23,10 @@ export interface LanguageTools {
   mapTestFinishDataToLookupKey(testFinishData: TestFinish): string | undefined
   // Maps test case info into a unique key  that can be used to find an individual test case in a run.
   mapTestCaseInfoToLookupKey(testCaseInfo: TestCaseInfo): string | undefined
+  // Whether source directory runs should be delegated to source files.
+  shouldDeferSourceDirectoryRun(): boolean
+  // Returns a build-server argument that narrows execution to a source file.
+  getTestFileArgument(uri: vscode.Uri | undefined): string | undefined
   getDebugRemoteRoot(
     workspaceRoot: string,
     targetUri: string

--- a/src/language-tools/typescript.ts
+++ b/src/language-tools/typescript.ts
@@ -18,7 +18,8 @@ export class TypeScriptLanguageTools
   isValidTestSource(uri: string): boolean {
     if (uri.includes('node_modules')) return false
     if (uri.includes('bazel-out')) return false
-    return true
+    // Only expose actual Jest test files, not fixtures/helpers under test dirs.
+    return TEST_FILE_REGEX.test(path.basename(uri))
   }
 
   getDebugRemoteRoot(

--- a/src/language-tools/typescript.ts
+++ b/src/language-tools/typescript.ts
@@ -8,6 +8,7 @@ import {SourceFileTestCaseInfo, TestCaseInfo} from '../test-info/test-info'
 import {BaseLanguageTools} from './base'
 import {JUnitStyleTestCaseData, TestFinishDataKind} from '../bsp/bsp-ext'
 import * as bsp from '../bsp/bsp'
+import {Utils} from '../utils/utils'
 
 const TEST_FILE_REGEX = /^.+\.(test|spec|browser|node)\.tsx?$/
 
@@ -20,6 +21,23 @@ export class TypeScriptLanguageTools
     if (uri.includes('bazel-out')) return false
     // Only expose actual Jest test files, not fixtures/helpers under test dirs.
     return TEST_FILE_REGEX.test(path.basename(uri))
+  }
+
+  shouldDeferSourceDirectoryRun(): boolean {
+    return true
+  }
+
+  getTestFileArgument(uri: vscode.Uri | undefined): string | undefined {
+    if (!uri) {
+      return undefined
+    }
+
+    const workspaceRoot = Utils.getWorkspaceRoot()
+    if (!workspaceRoot) {
+      return undefined
+    }
+
+    return path.relative(workspaceRoot.fsPath, uri.fsPath)
   }
 
   getDebugRemoteRoot(

--- a/src/test-info/test-info.ts
+++ b/src/test-info/test-info.ts
@@ -1,11 +1,9 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
-import * as fs from 'fs'
 import {BuildTarget, TestParams, TestResult, StatusCode} from '../bsp/bsp'
 import {TestParamsDataKind, BazelTestParamsData} from '../bsp/bsp-ext'
 import {TestCaseStatus, TestRunTracker} from '../test-runner/run-tracker'
-import {DocumentTestItem} from '../language-tools/manager'
-import {Utils} from '../utils/utils'
+import type {DocumentTestItem, LanguageTools} from '../language-tools/manager'
 
 export enum TestItemType {
   Root,
@@ -100,12 +98,18 @@ export class TargetDirTestCaseInfo extends TestCaseInfo {
 export class BuildTargetTestCaseInfo extends TestCaseInfo {
   public readonly type: TestItemType
   public readonly target: BuildTarget
+  protected readonly languageTools: LanguageTools | undefined
 
-  constructor(test: vscode.TestItem, target: BuildTarget) {
+  constructor(
+    test: vscode.TestItem,
+    target: BuildTarget,
+    languageTools?: LanguageTools
+  ) {
     super(test, target)
     this.type = TestItemType.BazelTarget
     // This class and any that extend it are guaranteed to include a target.
     this.target = target
+    this.languageTools = languageTools
   }
 
   prepareTestRunParams(currentRun: TestRunTracker): TestParams | undefined {
@@ -195,14 +199,19 @@ export class BuildTargetTestCaseInfo extends TestCaseInfo {
 export class SourceDirTestCaseInfo extends BuildTargetTestCaseInfo {
   public readonly type: TestItemType
   private readonly dir: string
-  constructor(test: vscode.TestItem, target: BuildTarget, dir: string) {
-    super(test, target)
+  constructor(
+    test: vscode.TestItem,
+    target: BuildTarget,
+    dir: string,
+    languageTools?: LanguageTools
+  ) {
+    super(test, target, languageTools)
     this.dir = dir
     this.type = TestItemType.SourceDirectory
   }
 
   prepareTestRunParams(currentRun: TestRunTracker): TestParams | undefined {
-    if (isTypeScriptTarget(this.target)) {
+    if (this.languageTools?.shouldDeferSourceDirectoryRun()) {
       return
     }
 
@@ -233,8 +242,12 @@ export class SourceFileTestCaseInfo extends BuildTargetTestCaseInfo {
   public readonly type: TestItemType
   protected details: DocumentTestItem | undefined
 
-  constructor(test: vscode.TestItem, target: BuildTarget) {
-    super(test, target)
+  constructor(
+    test: vscode.TestItem,
+    target: BuildTarget,
+    languageTools?: LanguageTools
+  ) {
+    super(test, target, languageTools)
     this.type = TestItemType.SourceFile
   }
 
@@ -263,20 +276,13 @@ export class SourceFileTestCaseInfo extends BuildTargetTestCaseInfo {
   processTestRunResult(currentRun: TestRunTracker, result: TestResult): void {
     updateStatus(this.testItem, currentRun, result)
 
-    const children = Array.from(
-      currentRun.pendingChildrenIterator(this.testItem, TestItemType.SourceFile)
-    )
-    const childStatuses = parseJestChildStatuses(result, children)
-
-    for (const child of children) {
-      const status = childStatuses.get(getStatusKey(child))
-      if (status) {
-        currentRun.updateStatus(child.testItem, status)
-      } else if (result.statusCode === StatusCode.Ok) {
+    for (const child of currentRun.pendingChildrenIterator(
+      this.testItem,
+      TestItemType.SourceFile
+    )) {
+      if (result.statusCode === StatusCode.Ok) {
         currentRun.updateStatus(child.testItem, TestCaseStatus.Passed)
-      } else if (childStatuses.size === 0) {
-        currentRun.updateStatus(child.testItem, TestCaseStatus.Failed)
-      } else {
+      } else if (child.testItem.children.size > 0) {
         currentRun.updateStatus(child.testItem, TestCaseStatus.Inherit)
       }
     }
@@ -284,16 +290,7 @@ export class SourceFileTestCaseInfo extends BuildTargetTestCaseInfo {
 
   private getTestFileArgument(): string | undefined {
     const uri = this.details?.uri ?? this.testItem.uri
-    if (!uri || !isTypeScriptTarget(this.target)) {
-      return undefined
-    }
-
-    const workspaceRoot = Utils.getWorkspaceRoot()
-    if (!workspaceRoot) {
-      return undefined
-    }
-
-    return path.relative(workspaceRoot.fsPath, uri.fsPath)
+    return this.languageTools?.getTestFileArgument(uri)
   }
 
   /**
@@ -334,9 +331,10 @@ export class TestItemTestCaseInfo extends SourceFileTestCaseInfo {
   constructor(
     test: vscode.TestItem,
     target: BuildTarget,
-    details: DocumentTestItem
+    details: DocumentTestItem,
+    languageTools?: LanguageTools
   ) {
-    super(test, target)
+    super(test, target, languageTools)
     this.type = TestItemType.TestCase
     this.details = details
   }
@@ -365,107 +363,5 @@ function updateStatus(
     currentRun.updateStatus(item, TestCaseStatus.Passed)
   } else {
     currentRun.updateStatus(item, TestCaseStatus.Skipped)
-  }
-}
-
-function isTypeScriptTarget(target: BuildTarget): boolean {
-  return (
-    target.languageIds?.includes('typescript') ||
-    target.languageIds?.includes('typescriptreact')
-  )
-}
-
-function parseJestChildStatuses(
-  result: TestResult,
-  children: TestCaseInfo[]
-): Map<string, TestCaseStatus> {
-  const statuses = new Map<string, TestCaseStatus>()
-  const labelCounts = new Map<string, number>()
-  const suiteStack: {indent: number; name: string}[] = []
-
-  for (const child of children) {
-    labelCounts.set(
-      child.testItem.label,
-      (labelCounts.get(child.testItem.label) ?? 0) + 1
-    )
-  }
-
-  for (const line of getResultOutputLines(result)) {
-    const cleanLine = Utils.removeAnsiEscapeCodes(line).replace(/\r$/, '')
-    const statusMatch = cleanLine.match(
-      /^(\s*)([✓✔√✕✖×])\s+(.+?)(?:\s+\(\d+(?:\.\d+)?\s*(?:m?s|μs|ns)\))?$/
-    )
-
-    if (statusMatch) {
-      const statusIndent = statusMatch[1].length
-      const status = /^[✓✔√]$/.test(statusMatch[2])
-        ? TestCaseStatus.Passed
-        : TestCaseStatus.Failed
-      const testName = statusMatch[3].trim()
-      const activeSuites = suiteStack
-        .filter(suite => suite.indent < statusIndent)
-        .map(suite => suite.name)
-      const lookupKey = [...activeSuites, testName].join(' ')
-      const matchingChild =
-        children.find(child => getStatusKey(child) === lookupKey) ??
-        (labelCounts.get(testName) === 1
-          ? children.find(child => child.testItem.label === testName)
-          : undefined)
-
-      if (matchingChild) {
-        statuses.set(getStatusKey(matchingChild), status)
-      }
-      continue
-    }
-
-    const suiteMatch = cleanLine.match(
-      /^(\s{2,})(?!(?:Test Suites|Tests|Snapshots|Time|Ran all test suites|Force exiting Jest):)(\S.*)$/
-    )
-    if (suiteMatch) {
-      const suiteIndent = suiteMatch[1].length
-      while (
-        suiteStack.length > 0 &&
-        suiteIndent <= suiteStack[suiteStack.length - 1].indent
-      ) {
-        suiteStack.pop()
-      }
-      suiteStack.push({
-        indent: suiteIndent,
-        name: suiteMatch[2].trim(),
-      })
-    } else if (cleanLine.trim().length > 0 && !cleanLine.startsWith(' ')) {
-      suiteStack.length = 0
-    }
-  }
-
-  return statuses
-}
-
-function getStatusKey(child: TestCaseInfo): string {
-  if (child instanceof SourceFileTestCaseInfo) {
-    return child.getDocumentTestItem()?.lookupKey ?? child.testItem.label
-  }
-
-  return child.testItem.label
-}
-
-function getResultOutputLines(result: TestResult): string[] {
-  const stdout = result.data?.stdoutCollector?.lines ?? []
-  const stderr = result.data?.stderrCollector?.lines ?? []
-  const outputLines = [...stdout, ...stderr]
-  const testLogLines = outputLines.flatMap(readTestLogLines)
-  return [...outputLines, ...testLogLines]
-}
-
-function readTestLogLines(line: string): string[] {
-  const match = line.match(/\/\S+\/test\.log\b/)
-  if (!match) {
-    return []
-  }
-
-  try {
-    return fs.readFileSync(match[0], 'utf8').split('\n')
-  } catch {
-    return []
   }
 }

--- a/src/test-info/test-info.ts
+++ b/src/test-info/test-info.ts
@@ -339,6 +339,28 @@ export class TestItemTestCaseInfo extends SourceFileTestCaseInfo {
     this.details = details
   }
 
+  processTestRunResult(currentRun: TestRunTracker, result: TestResult): void {
+    if (
+      result.statusCode === StatusCode.Error &&
+      this.testItem.children.size > 0
+    ) {
+      currentRun.updateStatus(this.testItem, TestCaseStatus.Inherit)
+
+      for (const child of currentRun.pendingChildrenIterator(
+        this.testItem,
+        TestItemType.SourceFile
+      )) {
+        if (child.testItem.children.size > 0) {
+          currentRun.updateStatus(child.testItem, TestCaseStatus.Inherit)
+        }
+      }
+
+      return
+    }
+
+    super.processTestRunResult(currentRun, result)
+  }
+
   /**
    * Sets a test case's label to its name.
    * @param relativeToItem will be ignored in this implementation

--- a/src/test-info/test-info.ts
+++ b/src/test-info/test-info.ts
@@ -1,10 +1,11 @@
 import * as vscode from 'vscode'
 import * as path from 'path'
+import * as fs from 'fs'
 import {BuildTarget, TestParams, TestResult, StatusCode} from '../bsp/bsp'
 import {TestParamsDataKind, BazelTestParamsData} from '../bsp/bsp-ext'
 import {TestCaseStatus, TestRunTracker} from '../test-runner/run-tracker'
-import {DocumentTestItem, LanguageToolManager} from '../language-tools/manager'
-import {getExtensionSetting, SettingName} from '../utils/settings'
+import {DocumentTestItem} from '../language-tools/manager'
+import {Utils} from '../utils/utils'
 
 export enum TestItemType {
   Root,
@@ -200,6 +201,14 @@ export class SourceDirTestCaseInfo extends BuildTargetTestCaseInfo {
     this.type = TestItemType.SourceDirectory
   }
 
+  prepareTestRunParams(currentRun: TestRunTracker): TestParams | undefined {
+    if (isTypeScriptTarget(this.target)) {
+      return
+    }
+
+    return super.prepareTestRunParams(currentRun)
+  }
+
   /**
    * Sets a source directory's name to be relative to any parent source directory.
    * @param relativeToItem Item against which the label will be calculated.
@@ -233,8 +242,15 @@ export class SourceFileTestCaseInfo extends BuildTargetTestCaseInfo {
     if (this.target === undefined) return
 
     const params = super.prepareTestRunParams(currentRun)
+
+    const fileArgument = this.getTestFileArgument()
+    if (fileArgument) {
+      params?.arguments?.push(fileArgument)
+    }
+
     if (
       params?.dataKind === TestParamsDataKind.BazelTest &&
+      this.type === TestItemType.TestCase &&
       this.details?.testFilter
     ) {
       const bazelParams = params.data as BazelTestParamsData
@@ -242,6 +258,42 @@ export class SourceFileTestCaseInfo extends BuildTargetTestCaseInfo {
     }
 
     return params
+  }
+
+  processTestRunResult(currentRun: TestRunTracker, result: TestResult): void {
+    updateStatus(this.testItem, currentRun, result)
+
+    const children = Array.from(
+      currentRun.pendingChildrenIterator(this.testItem, TestItemType.SourceFile)
+    )
+    const childStatuses = parseJestChildStatuses(result, children)
+
+    for (const child of children) {
+      const status = childStatuses.get(getStatusKey(child))
+      if (status) {
+        currentRun.updateStatus(child.testItem, status)
+      } else if (result.statusCode === StatusCode.Ok) {
+        currentRun.updateStatus(child.testItem, TestCaseStatus.Passed)
+      } else if (childStatuses.size === 0) {
+        currentRun.updateStatus(child.testItem, TestCaseStatus.Failed)
+      } else {
+        currentRun.updateStatus(child.testItem, TestCaseStatus.Inherit)
+      }
+    }
+  }
+
+  private getTestFileArgument(): string | undefined {
+    const uri = this.details?.uri ?? this.testItem.uri
+    if (!uri || !isTypeScriptTarget(this.target)) {
+      return undefined
+    }
+
+    const workspaceRoot = Utils.getWorkspaceRoot()
+    if (!workspaceRoot) {
+      return undefined
+    }
+
+    return path.relative(workspaceRoot.fsPath, uri.fsPath)
   }
 
   /**
@@ -313,5 +365,107 @@ function updateStatus(
     currentRun.updateStatus(item, TestCaseStatus.Passed)
   } else {
     currentRun.updateStatus(item, TestCaseStatus.Skipped)
+  }
+}
+
+function isTypeScriptTarget(target: BuildTarget): boolean {
+  return (
+    target.languageIds?.includes('typescript') ||
+    target.languageIds?.includes('typescriptreact')
+  )
+}
+
+function parseJestChildStatuses(
+  result: TestResult,
+  children: TestCaseInfo[]
+): Map<string, TestCaseStatus> {
+  const statuses = new Map<string, TestCaseStatus>()
+  const labelCounts = new Map<string, number>()
+  const suiteStack: {indent: number; name: string}[] = []
+
+  for (const child of children) {
+    labelCounts.set(
+      child.testItem.label,
+      (labelCounts.get(child.testItem.label) ?? 0) + 1
+    )
+  }
+
+  for (const line of getResultOutputLines(result)) {
+    const cleanLine = Utils.removeAnsiEscapeCodes(line).replace(/\r$/, '')
+    const statusMatch = cleanLine.match(
+      /^(\s*)([✓✔√✕✖×])\s+(.+?)(?:\s+\(\d+(?:\.\d+)?\s*(?:m?s|μs|ns)\))?$/
+    )
+
+    if (statusMatch) {
+      const statusIndent = statusMatch[1].length
+      const status = /^[✓✔√]$/.test(statusMatch[2])
+        ? TestCaseStatus.Passed
+        : TestCaseStatus.Failed
+      const testName = statusMatch[3].trim()
+      const activeSuites = suiteStack
+        .filter(suite => suite.indent < statusIndent)
+        .map(suite => suite.name)
+      const lookupKey = [...activeSuites, testName].join(' ')
+      const matchingChild =
+        children.find(child => getStatusKey(child) === lookupKey) ??
+        (labelCounts.get(testName) === 1
+          ? children.find(child => child.testItem.label === testName)
+          : undefined)
+
+      if (matchingChild) {
+        statuses.set(getStatusKey(matchingChild), status)
+      }
+      continue
+    }
+
+    const suiteMatch = cleanLine.match(
+      /^(\s{2,})(?!(?:Test Suites|Tests|Snapshots|Time|Ran all test suites|Force exiting Jest):)(\S.*)$/
+    )
+    if (suiteMatch) {
+      const suiteIndent = suiteMatch[1].length
+      while (
+        suiteStack.length > 0 &&
+        suiteIndent <= suiteStack[suiteStack.length - 1].indent
+      ) {
+        suiteStack.pop()
+      }
+      suiteStack.push({
+        indent: suiteIndent,
+        name: suiteMatch[2].trim(),
+      })
+    } else if (cleanLine.trim().length > 0 && !cleanLine.startsWith(' ')) {
+      suiteStack.length = 0
+    }
+  }
+
+  return statuses
+}
+
+function getStatusKey(child: TestCaseInfo): string {
+  if (child instanceof SourceFileTestCaseInfo) {
+    return child.getDocumentTestItem()?.lookupKey ?? child.testItem.label
+  }
+
+  return child.testItem.label
+}
+
+function getResultOutputLines(result: TestResult): string[] {
+  const stdout = result.data?.stdoutCollector?.lines ?? []
+  const stderr = result.data?.stderrCollector?.lines ?? []
+  const outputLines = [...stdout, ...stderr]
+  const testLogLines = outputLines.flatMap(readTestLogLines)
+  return [...outputLines, ...testLogLines]
+}
+
+function readTestLogLines(line: string): string[] {
+  const match = line.match(/\/\S+\/test\.log\b/)
+  if (!match) {
+    return []
+  }
+
+  try {
+    return fs.readFileSync(match[0], 'utf8').split('\n')
+  } catch {
+    return []
   }
 }

--- a/src/test-info/test-item-factory.ts
+++ b/src/test-info/test-item-factory.ts
@@ -15,7 +15,7 @@ import {
   TestItemType,
 } from './test-info'
 import {BuildTarget, SourceItem} from '../bsp/bsp'
-import {DocumentTestItem} from '../language-tools/manager'
+import {DocumentTestItem, LanguageToolManager} from '../language-tools/manager'
 
 /**
  * Class which includes various methods to create test items.
@@ -25,6 +25,8 @@ import {DocumentTestItem} from '../language-tools/manager'
 export class TestItemFactory {
   @Inject(EXTENSION_CONTEXT_TOKEN) private readonly ctx: vscode.ExtensionContext
   @Inject(TestCaseStore) private readonly store: TestCaseStore
+  @Inject(LanguageToolManager)
+  private readonly languageToolManager: LanguageToolManager
 
   /**
    * Create a root test item for the test explorer.
@@ -58,7 +60,11 @@ export class TestItemFactory {
       target.displayName ?? target.id.uri,
       uri
     )
-    const testCaseInfo = new BuildTargetTestCaseInfo(newTest, target)
+    const testCaseInfo = new BuildTargetTestCaseInfo(
+      newTest,
+      target,
+      this.languageToolManager.getLanguageTools(target)
+    )
     this.store.testCaseMetadata.set(newTest, testCaseInfo)
 
     newTest.canResolveChildren = true
@@ -87,7 +93,11 @@ export class TestItemFactory {
     )
     this.store.testCaseMetadata.set(
       newTest,
-      new SourceFileTestCaseInfo(newTest, target)
+      new SourceFileTestCaseInfo(
+        newTest,
+        target,
+        this.languageToolManager.getLanguageTools(target)
+      )
     )
 
     return newTest
@@ -177,7 +187,12 @@ export class TestItemFactory {
     newTest.range = details.range
     this.store.testCaseMetadata.set(
       newTest,
-      new TestItemTestCaseInfo(newTest, target, details)
+      new TestItemTestCaseInfo(
+        newTest,
+        target,
+        details,
+        this.languageToolManager.getLanguageTools(target)
+      )
     )
     return newTest
   }
@@ -218,7 +233,12 @@ export class TestItemFactory {
     const newTest = this.store.testController.createTestItem(id, relPath, uri)
     this.store.testCaseMetadata.set(
       newTest,
-      new SourceDirTestCaseInfo(newTest, target, relPath)
+      new SourceDirTestCaseInfo(
+        newTest,
+        target,
+        relPath,
+        this.languageToolManager.getLanguageTools(target)
+      )
     )
     return newTest
   }

--- a/src/test-runner/run-tracker.ts
+++ b/src/test-runner/run-tracker.ts
@@ -130,8 +130,13 @@ export class TestRunTracker implements TaskOriginHandlers {
       await callback(item.testItem, this.cancelToken)
 
       if (this.status.get(item.testItem) === initialStatus) {
-        // If an updated status has not been set by the callback, consider it skipped.
-        this.updateStatus(item.testItem, TestCaseStatus.Skipped)
+        // Container nodes that defer execution to their children should not
+        // override the aggregate child status in Test Explorer.
+        const fallbackStatus =
+          item.testItem.children.size > 0
+            ? TestCaseStatus.Inherit
+            : TestCaseStatus.Skipped
+        this.updateStatus(item.testItem, fallbackStatus)
       }
     }
 

--- a/src/test/suite/language-tools/typescript.test.ts
+++ b/src/test/suite/language-tools/typescript.test.ts
@@ -360,7 +360,7 @@ describe('Outer Suite', () => {
     test('returns false for fixture source paths', async () => {
       assert.strictEqual(
         languageTools.isValidTestSource(
-          'file:///workspace/src/fixtures/banner-step-fixture.ts'
+          'file:///workspace/src/fixtures/sample-helper-fixture.ts'
         ),
         false
       )

--- a/src/test/suite/language-tools/typescript.test.ts
+++ b/src/test/suite/language-tools/typescript.test.ts
@@ -356,6 +356,15 @@ describe('Outer Suite', () => {
         true
       )
     })
+
+    test('returns false for fixture source paths', async () => {
+      assert.strictEqual(
+        languageTools.isValidTestSource(
+          'file:///workspace/src/fixtures/banner-step-fixture.ts'
+        ),
+        false
+      )
+    })
   })
 
   suite('inferSourcesFromTarget', () => {

--- a/src/test/suite/run-tracker.test.ts
+++ b/src/test/suite/run-tracker.test.ts
@@ -201,11 +201,8 @@ suite('Test Run Tracker', () => {
     assert.equal(runSpy.passed.callCount, nonIncludedItems.length)
     nonIncludedItems.forEach(item => assert.ok(remainingItems.has(item)))
 
-    // Since the callback does not update the parents, remaining items marked skipped.
-    assert.equal(
-      runSpy.skipped.callCount,
-      createdTestItems.length - nonIncludedItems.length
-    )
+    // Since the callback does not update the parents, they inherit child status.
+    assert.equal(runSpy.skipped.callCount, 0)
   })
 
   test('filtered pending children', async () => {

--- a/src/test/suite/test-info.test.ts
+++ b/src/test/suite/test-info.test.ts
@@ -561,18 +561,15 @@ suite('TestInfo', () => {
         .stub(fs, 'readFileSync')
         .returns(
           [
-            '    ✕ should correctly set FileUploader endpoint for production (8 ms)',
-            '    ✓ should correctly set FileUploader endpoint for critical (1 ms)',
+            '    ✕ fails one child test (8 ms)',
+            '    ✓ passes a sibling child test (1 ms)',
           ].join('\n')
         )
 
-      const failed = createTypeScriptTestCase(
-        'failed',
-        'should correctly set FileUploader endpoint for production'
-      )
+      const failed = createTypeScriptTestCase('failed', 'fails one child test')
       const passed = createTypeScriptTestCase(
         'passed',
-        'should correctly set FileUploader endpoint for critical'
+        'passes a sibling child test'
       )
       currentRun.pendingChildrenIterator.returns(
         (function* () {
@@ -590,7 +587,7 @@ suite('TestInfo', () => {
         originId: 'sample',
         data: {
           stdoutCollector: {
-            lines: ['FAIL: //sample:test (see /private/tmp/sample/test.log)'],
+            lines: ['FAIL: //sample:test (see /tmp/sample/test.log)'],
           },
         },
       }
@@ -643,7 +640,7 @@ suite('TestInfo', () => {
         originId: 'sample',
         data: {
           stdoutCollector: {
-            lines: ['FAIL: //sample:test (see /private/tmp/sample/test.log)'],
+            lines: ['FAIL: //sample:test (see /tmp/sample/test.log)'],
           },
         },
       }

--- a/src/test/suite/test-info.test.ts
+++ b/src/test/suite/test-info.test.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode'
 import * as assert from 'assert'
+import * as fs from 'fs'
 import sinon from 'sinon'
 import {
   BuildTargetTestCaseInfo,
@@ -15,6 +16,7 @@ import {TestCaseStatus, TestRunTracker} from '../../test-runner/run-tracker'
 import {beforeEach, afterEach} from 'mocha'
 import {TestParamsDataKind} from '../../bsp/bsp-ext'
 import {DocumentTestItem} from '../../language-tools/manager'
+import {Utils} from '../../utils/utils'
 
 suite('TestInfo', () => {
   const sampleTarget: BuildTarget = {
@@ -23,6 +25,10 @@ suite('TestInfo', () => {
     languageIds: [],
     dependencies: [],
     capabilities: {},
+  }
+  const sampleTypeScriptTarget: BuildTarget = {
+    ...sampleTarget,
+    languageIds: ['typescript'],
   }
 
   let testController: vscode.TestController
@@ -91,7 +97,7 @@ suite('TestInfo', () => {
       }
     })
 
-    test('source directory', async () => {
+    test('non-typescript source directory runs target directly', async () => {
       const testItem = testController.createTestItem('sample', 'sample')
       const testInfo = new SourceDirTestCaseInfo(
         testItem,
@@ -105,6 +111,18 @@ suite('TestInfo', () => {
         const result = testInfo.prepareTestRunParams(currentRun)
         assert.deepStrictEqual(result, testCase.expectedResult)
       }
+    })
+
+    test('typescript source directory defers to source file runs', async () => {
+      const testItem = testController.createTestItem('sample', 'sample')
+      const testInfo = new SourceDirTestCaseInfo(
+        testItem,
+        sampleTypeScriptTarget,
+        '/sample/dir'
+      )
+      const currentRun = sandbox.createStubInstance(TestRunTracker)
+      const result = testInfo.prepareTestRunParams(currentRun)
+      assert.equal(result, undefined)
     })
 
     test('source file', async () => {
@@ -143,6 +161,66 @@ suite('TestInfo', () => {
       }
     })
 
+    test('typescript source file adds file argument', async () => {
+      sandbox
+        .stub(Utils, 'getWorkspaceRoot')
+        .returns(vscode.Uri.file('/sample'))
+
+      const testItem = testController.createTestItem('sample', 'sample')
+      const sampleDetails: DocumentTestItem = {
+        uri: vscode.Uri.file('/sample/src/example/__tests__/sample.browser.ts'),
+        name: 'sample.browser.ts',
+        parent: undefined,
+        range: new vscode.Range(0, 0, 0, 0),
+        testFilter: '',
+      }
+
+      const testInfo = new SourceFileTestCaseInfo(
+        testItem,
+        sampleTypeScriptTarget
+      )
+      testInfo.setDocumentTestItem(sampleDetails)
+
+      const currentRun = sandbox.createStubInstance(TestRunTracker)
+      sandbox.stub(currentRun, 'originName').get(() => 'sample')
+      currentRun.getRunProfileKind.returns(vscode.TestRunProfileKind.Run)
+
+      const result = testInfo.prepareTestRunParams(currentRun)
+      assert.ok(result)
+      assert.deepStrictEqual(result.arguments, [
+        'src/example/__tests__/sample.browser.ts',
+      ])
+      assert.deepStrictEqual(result.data, {
+        coverage: false,
+      })
+    })
+
+    test('typescript source file adds file argument before test case analysis', async () => {
+      sandbox
+        .stub(Utils, 'getWorkspaceRoot')
+        .returns(vscode.Uri.file('/sample'))
+
+      const testItem = testController.createTestItem(
+        'sample',
+        'sample',
+        vscode.Uri.file('/sample/src/example/__tests__/sample.browser.ts')
+      )
+      const testInfo = new SourceFileTestCaseInfo(
+        testItem,
+        sampleTypeScriptTarget
+      )
+
+      const currentRun = sandbox.createStubInstance(TestRunTracker)
+      sandbox.stub(currentRun, 'originName').get(() => 'sample')
+      currentRun.getRunProfileKind.returns(vscode.TestRunProfileKind.Run)
+
+      const result = testInfo.prepareTestRunParams(currentRun)
+      assert.ok(result)
+      assert.deepStrictEqual(result.arguments, [
+        'src/example/__tests__/sample.browser.ts',
+      ])
+    })
+
     test('test case', async () => {
       const testItem = testController.createTestItem('sample', 'sample')
       const sampleDetails: DocumentTestItem = {
@@ -178,6 +256,40 @@ suite('TestInfo', () => {
           coverage: testCase.expectedResult.data.coverage,
         })
       }
+    })
+
+    test('typescript test case adds file argument and test filter', async () => {
+      sandbox
+        .stub(Utils, 'getWorkspaceRoot')
+        .returns(vscode.Uri.file('/sample'))
+
+      const testItem = testController.createTestItem('sample', 'sample')
+      const sampleDetails: DocumentTestItem = {
+        uri: vscode.Uri.file('/sample/src/example/__tests__/sample.browser.ts'),
+        name: 'renders selected state',
+        parent: undefined,
+        range: new vscode.Range(0, 0, 0, 0),
+        testFilter: 'renders selected state',
+      }
+
+      const testInfo = new TestItemTestCaseInfo(
+        testItem,
+        sampleTypeScriptTarget,
+        sampleDetails
+      )
+      const currentRun = sandbox.createStubInstance(TestRunTracker)
+      sandbox.stub(currentRun, 'originName').get(() => 'sample')
+      currentRun.getRunProfileKind.returns(vscode.TestRunProfileKind.Run)
+
+      const result = testInfo.prepareTestRunParams(currentRun)
+      assert.ok(result)
+      assert.deepStrictEqual(result.arguments, [
+        'src/example/__tests__/sample.browser.ts',
+      ])
+      assert.deepStrictEqual(result.data, {
+        testFilter: sampleDetails.testFilter,
+        coverage: false,
+      })
     })
 
     test('root', async () => {
@@ -353,6 +465,23 @@ suite('TestInfo', () => {
       sandbox.stub(currentRun, 'originName').get(() => 'sample')
     })
 
+    function createTypeScriptTestCase(
+      id: string,
+      label: string,
+      lookupKey?: string
+    ) {
+      const item = testController.createTestItem(id, label)
+      const info = new TestItemTestCaseInfo(item, sampleTypeScriptTarget, {
+        uri: vscode.Uri.file('/sample/src/example/__tests__/sample.browser.ts'),
+        name: label,
+        parent: undefined,
+        range: new vscode.Range(0, 0, 0, 0),
+        testFilter: label,
+        lookupKey,
+      })
+      return {item, info}
+    }
+
     test('ok result, build target', async () => {
       const testInfo = new BuildTargetTestCaseInfo(testItem, sampleTarget)
       const bspResult: TestResult = {
@@ -372,6 +501,160 @@ suite('TestInfo', () => {
           testItem,
           TestItemType.BazelTarget
         )
+      )
+    })
+
+    test('ok result, source file marks pending children passed', async () => {
+      const childItem = testController.createTestItem('child', 'child')
+      const childInfo = new TestItemTestCaseInfo(
+        childItem,
+        sampleTypeScriptTarget,
+        {
+          uri: vscode.Uri.file(
+            '/sample/src/example/__tests__/sample.browser.ts'
+          ),
+          name: 'child',
+          parent: undefined,
+          range: new vscode.Range(0, 0, 0, 0),
+          testFilter: 'child',
+        }
+      )
+      currentRun.pendingChildrenIterator.returns(
+        (function* () {
+          yield childInfo
+        })()
+      )
+
+      const testInfo = new SourceFileTestCaseInfo(
+        testItem,
+        sampleTypeScriptTarget
+      )
+      const bspResult: TestResult = {
+        statusCode: StatusCode.Ok,
+        originId: 'sample',
+      }
+
+      testInfo.processTestRunResult(currentRun, bspResult)
+
+      assert.ok(
+        currentRun.updateStatus.calledWithExactly(
+          testItem,
+          TestCaseStatus.Passed
+        )
+      )
+      assert.ok(
+        currentRun.updateStatus.calledWithExactly(
+          childItem,
+          TestCaseStatus.Passed
+        )
+      )
+      assert.ok(
+        currentRun.pendingChildrenIterator.calledOnceWithExactly(
+          testItem,
+          TestItemType.SourceFile
+        )
+      )
+    })
+
+    test('error result, source file preserves mixed child statuses from jest output', async () => {
+      sandbox
+        .stub(fs, 'readFileSync')
+        .returns(
+          [
+            '    ✕ should correctly set FileUploader endpoint for production (8 ms)',
+            '    ✓ should correctly set FileUploader endpoint for critical (1 ms)',
+          ].join('\n')
+        )
+
+      const failed = createTypeScriptTestCase(
+        'failed',
+        'should correctly set FileUploader endpoint for production'
+      )
+      const passed = createTypeScriptTestCase(
+        'passed',
+        'should correctly set FileUploader endpoint for critical'
+      )
+      currentRun.pendingChildrenIterator.returns(
+        (function* () {
+          yield failed.info
+          yield passed.info
+        })()
+      )
+
+      const testInfo = new SourceFileTestCaseInfo(
+        testItem,
+        sampleTypeScriptTarget
+      )
+      const bspResult: TestResult = {
+        statusCode: StatusCode.Error,
+        originId: 'sample',
+        data: {
+          stdoutCollector: {
+            lines: ['FAIL: //sample:test (see /private/tmp/sample/test.log)'],
+          },
+        },
+      }
+
+      testInfo.processTestRunResult(currentRun, bspResult)
+
+      assert.ok(
+        currentRun.updateStatus.calledWith(failed.item, TestCaseStatus.Failed)
+      )
+      assert.ok(
+        currentRun.updateStatus.calledWith(passed.item, TestCaseStatus.Passed)
+      )
+    })
+
+    test('error result, source file uses lookup keys for duplicate jest labels', async () => {
+      sandbox
+        .stub(fs, 'readFileSync')
+        .returns(
+          [
+            '  loading state',
+            '    ✕ renders (8 ms)',
+            '  success state',
+            '    ✓ renders (1 ms)',
+          ].join('\n')
+        )
+
+      const failed = createTypeScriptTestCase(
+        'failed',
+        'renders',
+        'loading state renders'
+      )
+      const passed = createTypeScriptTestCase(
+        'passed',
+        'renders',
+        'success state renders'
+      )
+      currentRun.pendingChildrenIterator.returns(
+        (function* () {
+          yield failed.info
+          yield passed.info
+        })()
+      )
+
+      const testInfo = new SourceFileTestCaseInfo(
+        testItem,
+        sampleTypeScriptTarget
+      )
+      const bspResult: TestResult = {
+        statusCode: StatusCode.Error,
+        originId: 'sample',
+        data: {
+          stdoutCollector: {
+            lines: ['FAIL: //sample:test (see /private/tmp/sample/test.log)'],
+          },
+        },
+      }
+
+      testInfo.processTestRunResult(currentRun, bspResult)
+
+      assert.ok(
+        currentRun.updateStatus.calledWith(failed.item, TestCaseStatus.Failed)
+      )
+      assert.ok(
+        currentRun.updateStatus.calledWith(passed.item, TestCaseStatus.Passed)
       )
     })
 

--- a/src/test/suite/test-info.test.ts
+++ b/src/test/suite/test-info.test.ts
@@ -602,6 +602,62 @@ suite('TestInfo', () => {
       assert.ok(currentRun.updateStatus.neverCalledWith(childItem))
     })
 
+    test('error result, test suite inherits child statuses instead of aggregate target failure', async () => {
+      const childItem = testController.createTestItem('child', 'child')
+      testItem.children.add(childItem)
+      const childInfo = new TestItemTestCaseInfo(
+        childItem,
+        sampleTypeScriptTarget,
+        {
+          uri: vscode.Uri.file(
+            '/sample/src/example/__tests__/sample.browser.ts'
+          ),
+          name: 'child',
+          parent: undefined,
+          range: new vscode.Range(0, 0, 0, 0),
+          testFilter: 'child',
+        },
+        new TypeScriptLanguageTools()
+      )
+      currentRun.pendingChildrenIterator.returns(
+        (function* () {
+          yield childInfo
+        })()
+      )
+
+      const testInfo = new TestItemTestCaseInfo(
+        testItem,
+        sampleTypeScriptTarget,
+        {
+          uri: vscode.Uri.file(
+            '/sample/src/example/__tests__/sample.browser.ts'
+          ),
+          name: 'suite',
+          parent: undefined,
+          range: new vscode.Range(0, 0, 0, 0),
+          testFilter: 'suite',
+        },
+        new TypeScriptLanguageTools()
+      )
+      const bspResult: TestResult = {
+        statusCode: StatusCode.Error,
+        originId: 'sample',
+        data: {
+          stdoutCollector: {lines: ['FAIL: //sample:test']},
+        },
+      }
+
+      testInfo.processTestRunResult(currentRun, bspResult)
+
+      assert.ok(
+        currentRun.updateStatus.calledOnceWithExactly(
+          testItem,
+          TestCaseStatus.Inherit
+        )
+      )
+      assert.ok(currentRun.updateStatus.neverCalledWith(childItem))
+    })
+
     test('error result', async () => {
       const testInfo = new BuildTargetTestCaseInfo(testItem, sampleTarget)
       const bspResult: TestResult = {

--- a/src/test/suite/test-info.test.ts
+++ b/src/test/suite/test-info.test.ts
@@ -156,7 +156,6 @@ suite('TestInfo', () => {
           }
         }
         assert.deepStrictEqual(result.data, {
-          testFilter: sampleDetails.testFilter,
           coverage: testCase.expectedResult.data.coverage,
         })
       }

--- a/src/test/suite/test-info.test.ts
+++ b/src/test/suite/test-info.test.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode'
 import * as assert from 'assert'
-import * as fs from 'fs'
 import sinon from 'sinon'
 import {
   BuildTargetTestCaseInfo,
@@ -17,6 +16,7 @@ import {beforeEach, afterEach} from 'mocha'
 import {TestParamsDataKind} from '../../bsp/bsp-ext'
 import {DocumentTestItem} from '../../language-tools/manager'
 import {Utils} from '../../utils/utils'
+import {TypeScriptLanguageTools} from '../../language-tools/typescript'
 
 suite('TestInfo', () => {
   const sampleTarget: BuildTarget = {
@@ -118,7 +118,8 @@ suite('TestInfo', () => {
       const testInfo = new SourceDirTestCaseInfo(
         testItem,
         sampleTypeScriptTarget,
-        '/sample/dir'
+        '/sample/dir',
+        new TypeScriptLanguageTools()
       )
       const currentRun = sandbox.createStubInstance(TestRunTracker)
       const result = testInfo.prepareTestRunParams(currentRun)
@@ -177,7 +178,8 @@ suite('TestInfo', () => {
 
       const testInfo = new SourceFileTestCaseInfo(
         testItem,
-        sampleTypeScriptTarget
+        sampleTypeScriptTarget,
+        new TypeScriptLanguageTools()
       )
       testInfo.setDocumentTestItem(sampleDetails)
 
@@ -207,7 +209,8 @@ suite('TestInfo', () => {
       )
       const testInfo = new SourceFileTestCaseInfo(
         testItem,
-        sampleTypeScriptTarget
+        sampleTypeScriptTarget,
+        new TypeScriptLanguageTools()
       )
 
       const currentRun = sandbox.createStubInstance(TestRunTracker)
@@ -275,7 +278,8 @@ suite('TestInfo', () => {
       const testInfo = new TestItemTestCaseInfo(
         testItem,
         sampleTypeScriptTarget,
-        sampleDetails
+        sampleDetails,
+        new TypeScriptLanguageTools()
       )
       const currentRun = sandbox.createStubInstance(TestRunTracker)
       sandbox.stub(currentRun, 'originName').get(() => 'sample')
@@ -465,23 +469,6 @@ suite('TestInfo', () => {
       sandbox.stub(currentRun, 'originName').get(() => 'sample')
     })
 
-    function createTypeScriptTestCase(
-      id: string,
-      label: string,
-      lookupKey?: string
-    ) {
-      const item = testController.createTestItem(id, label)
-      const info = new TestItemTestCaseInfo(item, sampleTypeScriptTarget, {
-        uri: vscode.Uri.file('/sample/src/example/__tests__/sample.browser.ts'),
-        name: label,
-        parent: undefined,
-        range: new vscode.Range(0, 0, 0, 0),
-        testFilter: label,
-        lookupKey,
-      })
-      return {item, info}
-    }
-
     test('ok result, build target', async () => {
       const testInfo = new BuildTargetTestCaseInfo(testItem, sampleTarget)
       const bspResult: TestResult = {
@@ -556,25 +543,42 @@ suite('TestInfo', () => {
       )
     })
 
-    test('error result, source file preserves mixed child statuses from jest output', async () => {
-      sandbox
-        .stub(fs, 'readFileSync')
-        .returns(
-          [
-            '    ✕ fails one child test (8 ms)',
-            '    ✓ passes a sibling child test (1 ms)',
-          ].join('\n')
-        )
-
-      const failed = createTypeScriptTestCase('failed', 'fails one child test')
-      const passed = createTypeScriptTestCase(
-        'passed',
-        'passes a sibling child test'
+    test('error result, source file clears containers and leaves leaf tests for server-reported statuses', async () => {
+      const suiteItem = testController.createTestItem('suite', 'suite')
+      const childItem = testController.createTestItem('child', 'child')
+      suiteItem.children.add(childItem)
+      const suiteInfo = new TestItemTestCaseInfo(
+        suiteItem,
+        sampleTypeScriptTarget,
+        {
+          uri: vscode.Uri.file(
+            '/sample/src/example/__tests__/sample.browser.ts'
+          ),
+          name: 'suite',
+          parent: undefined,
+          range: new vscode.Range(0, 0, 0, 0),
+          testFilter: 'suite',
+        },
+        new TypeScriptLanguageTools()
+      )
+      const childInfo = new TestItemTestCaseInfo(
+        childItem,
+        sampleTypeScriptTarget,
+        {
+          uri: vscode.Uri.file(
+            '/sample/src/example/__tests__/sample.browser.ts'
+          ),
+          name: 'child',
+          parent: undefined,
+          range: new vscode.Range(0, 0, 0, 0),
+          testFilter: 'child',
+        },
+        new TypeScriptLanguageTools()
       )
       currentRun.pendingChildrenIterator.returns(
         (function* () {
-          yield failed.info
-          yield passed.info
+          yield suiteInfo
+          yield childInfo
         })()
       )
 
@@ -586,73 +590,16 @@ suite('TestInfo', () => {
         statusCode: StatusCode.Error,
         originId: 'sample',
         data: {
-          stdoutCollector: {
-            lines: ['FAIL: //sample:test (see /tmp/sample/test.log)'],
-          },
+          stdoutCollector: {lines: ['FAIL: //sample:test']},
         },
       }
 
       testInfo.processTestRunResult(currentRun, bspResult)
 
       assert.ok(
-        currentRun.updateStatus.calledWith(failed.item, TestCaseStatus.Failed)
+        currentRun.updateStatus.calledWith(suiteItem, TestCaseStatus.Inherit)
       )
-      assert.ok(
-        currentRun.updateStatus.calledWith(passed.item, TestCaseStatus.Passed)
-      )
-    })
-
-    test('error result, source file uses lookup keys for duplicate jest labels', async () => {
-      sandbox
-        .stub(fs, 'readFileSync')
-        .returns(
-          [
-            '  loading state',
-            '    ✕ renders (8 ms)',
-            '  success state',
-            '    ✓ renders (1 ms)',
-          ].join('\n')
-        )
-
-      const failed = createTypeScriptTestCase(
-        'failed',
-        'renders',
-        'loading state renders'
-      )
-      const passed = createTypeScriptTestCase(
-        'passed',
-        'renders',
-        'success state renders'
-      )
-      currentRun.pendingChildrenIterator.returns(
-        (function* () {
-          yield failed.info
-          yield passed.info
-        })()
-      )
-
-      const testInfo = new SourceFileTestCaseInfo(
-        testItem,
-        sampleTypeScriptTarget
-      )
-      const bspResult: TestResult = {
-        statusCode: StatusCode.Error,
-        originId: 'sample',
-        data: {
-          stdoutCollector: {
-            lines: ['FAIL: //sample:test (see /tmp/sample/test.log)'],
-          },
-        },
-      }
-
-      testInfo.processTestRunResult(currentRun, bspResult)
-
-      assert.ok(
-        currentRun.updateStatus.calledWith(failed.item, TestCaseStatus.Failed)
-      )
-      assert.ok(
-        currentRun.updateStatus.calledWith(passed.item, TestCaseStatus.Passed)
-      )
+      assert.ok(currentRun.updateStatus.neverCalledWith(childItem))
     })
 
     test('error result', async () => {

--- a/src/test/suite/test-item-factory.test.ts
+++ b/src/test/suite/test-item-factory.test.ts
@@ -13,7 +13,10 @@ import {TestItemFactory} from '../../test-info/test-item-factory'
 import * as assert from 'assert'
 import {BuildTarget, SourceItem, SourceItemKind} from '../../bsp/bsp'
 import {TestItemType} from '../../test-info/test-info'
-import {DocumentTestItem} from '../../language-tools/manager'
+import {
+  DocumentTestItem,
+  LanguageToolManager,
+} from '../../language-tools/manager'
 
 suite('Test Item Factory', () => {
   let ctx: vscode.ExtensionContext
@@ -33,7 +36,12 @@ suite('Test Item Factory', () => {
   beforeEach(async () => {
     ctx = {subscriptions: []} as unknown as vscode.ExtensionContext
     const moduleRef = await Test.createTestingModule({
-      providers: [contextProviderFactory(ctx), TestCaseStore, TestItemFactory],
+      providers: [
+        contextProviderFactory(ctx),
+        TestCaseStore,
+        TestItemFactory,
+        LanguageToolManager,
+      ],
     })
       .useMocker(token => {
         if (token === TEST_CONTROLLER_TOKEN) {


### PR DESCRIPTION
## Problem
Project and source-directory runs for TypeScript Jest targets were executing the broad Bazel target without narrowing to the selected test file. A run could therefore fail because of another file or suite in the same Bazel target, while the selected file or suite had passing tests. Test Explorer then only had the aggregate target failure to apply and could show unrelated discovered tests or suite containers as failed.

## Summary
- Keep TypeScript-specific run behavior behind language tools.
- Run TypeScript source-directory selections at source-file granularity.
- Pass the selected TypeScript test file as a BSP test argument so Bazel/Jest narrows execution to that file.
- Keep non-TypeScript source-directory behavior unchanged.
- Let container/suite nodes inherit child statuses instead of forcing aggregate target failures onto them.
- Filter TypeScript source discovery to actual Jest test file names.

## Related server change
- Pairs with VirtusLab/bazel-bsp#48 so Jest child statuses can be reported when Bazel XML only contains an aggregate failed testcase and detailed Jest output is in `system-out`.

## Test plan
- `yarn test-compile`
- `yarn lint:single src/test-info/test-info.ts src/test/suite/test-info.test.ts`
- Manual: packaged and installed the extension locally, then verified file, directory, and suite runs use file-scoped execution and preserve individual child statuses for mixed pass/fail results.
