### PR TITLE
Scope generated project view to workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The extension is still under active development, but initial development release
 3. View the "Testing" panel, which will show progress of the load, and show available test targets once the load is complete.
 
 ### Adjusting project scope
-By default, the generated project view is scoped to the workspace folder opened in VS Code. To change that scope:
+When VS Code is opened to a nested workspace folder, the generated project view is scoped to that folder. If VS Code is opened at the repository root or another broad scope, adjust the project view before syncing:
 
 1. Click on the top level test case to open the .bazelproject that is in use.
 2. Adjust the `directories` or `targets` entries to include the desired scope.

--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ The extension is still under active development, but initial development release
 3. View the "Testing" panel, which will show progress of the load, and show available test targets once the load is complete.
 
 ### Adjusting project scope
+By default, the generated project view is scoped to the workspace folder opened in VS Code. To change that scope:
+
 1. Click on the top level test case to open the .bazelproject that is in use.
-2. Adjust the "targets" entry to include desired targets.
+2. Adjust the `directories` or `targets` entries to include the desired scope.
 3. Click the refresh (circular arrow) icon at the top of the "testing" panel to re-sync available targets.
 
 ### Syncing changes to targets

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The extension is still under active development, but initial development release
 3. View the "Testing" panel, which will show progress of the load, and show available test targets once the load is complete.
 
 ### Adjusting project scope
-When VS Code is opened to a nested workspace folder, the generated project view is scoped to that folder. If VS Code is opened at the repository root or another broad scope, adjust the project view before syncing:
+By default, the generated project view includes a placeholder target pattern for manual editing. If `bazelbsp.projectViewScopeDirectoryMinDepth` is configured and VS Code is opened to a workspace folder deep enough under the repository root, the generated project view is scoped to that folder. Otherwise, adjust the project view before syncing:
 
 1. Click on the top level test case to open the .bazelproject that is in use.
 2. Adjust the `directories` or `targets` entries to include the desired scope.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -38,7 +38,7 @@ As you interact with the VS Code UI, the client sends requests to this server ov
 4. Let the sync process complete. See "Sync Process" section below.
 
 ### Adjusting Project Scope
-When VS Code is opened to a nested workspace folder, the generated project view is scoped to that folder. If VS Code is opened at the repository root or another broad scope, adjust the project view before syncing:
+By default, the generated project view includes a placeholder target pattern for manual editing. If `bazelbsp.projectViewScopeDirectoryMinDepth` is configured and VS Code is opened to a workspace folder deep enough under the repository root, the generated project view is scoped to that folder. Otherwise, adjust the project view before syncing:
 
 1. Open Project View file: click on the file icon next to the "Bazel Test Targets" root test item
    ![image](https://github.com/uber/vscode-bazel-bsp/assets/92764374/795baab9-ec42-4b7d-9b1a-2e4033731b64)
@@ -104,6 +104,7 @@ To run with coverage, use the "Run with Coverage" option appearing next to the r
 ### Key Settings
 - `bazelBinaryPath`: If you have a specific Bazel binary to be used, set it here.  This will only be used when generating a new .bazelproject file to set the bazel_binary field.
 - `bazelProjectFilePath`: If you already have an existing project view file that you would prefer to use, point this setting to that location instead.  Be sure to reinstall the BSP server (Cmd+Shift+P → Install BSP Server) and reload the window to begin indexing based on the updated file.
+- `projectViewScopeDirectoryMinDepth`: If set, generated project views use the opened workspace folder as `directories` scope only when that folder is at least this many path segments under the repository root. Leave unset to generate the manual placeholder target instead.
 - `serverInstallMode`: Can be set to 'Auto' to install automatically in a new repo.
 - `serverVersion`: Determines which version of Bazel BSP will be installed.
 

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -38,7 +38,7 @@ As you interact with the VS Code UI, the client sends requests to this server ov
 4. Let the sync process complete. See "Sync Process" section below.
 
 ### Adjusting Project Scope
-The generated project view is scoped to the workspace folder opened in VS Code by default. To change that scope:
+When VS Code is opened to a nested workspace folder, the generated project view is scoped to that folder. If VS Code is opened at the repository root or another broad scope, adjust the project view before syncing:
 
 1. Open Project View file: click on the file icon next to the "Bazel Test Targets" root test item
    ![image](https://github.com/uber/vscode-bazel-bsp/assets/92764374/795baab9-ec42-4b7d-9b1a-2e4033731b64)
@@ -122,4 +122,3 @@ To run with coverage, use the "Run with Coverage" option appearing next to the r
   ![image](https://github.com/uber/vscode-bazel-bsp/assets/92764374/d9c376b8-74e8-4981-a400-ae2fb70ec2ae)
 
 - If a test is located under a different root node, or none, it may be coming a different extension.
-

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -35,13 +35,14 @@ As you interact with the VS Code UI, the client sends requests to this server ov
 1. Launch a workspace that contains .py or .java files, which will trigger extension activation.
 2. Accept the prompt to install the build server in the repo	
 3. Go to the "Testing" ![image](https://github.com/uber/vscode-bazel-bsp/assets/92764374/536205bd-6908-4184-9620-292aa2dfe7f6) panel in VS Code
-4. Adjust the project scope.  See "Adjusting Project Scope" section below.
-5. Let the sync process complete.  See "Sync Process" section below.
+4. Let the sync process complete. See "Sync Process" section below.
 
 ### Adjusting Project Scope
+The generated project view is scoped to the workspace folder opened in VS Code by default. To change that scope:
+
 1. Open Project View file: click on the file icon next to the "Bazel Test Targets" root test item
    ![image](https://github.com/uber/vscode-bazel-bsp/assets/92764374/795baab9-ec42-4b7d-9b1a-2e4033731b64)
-2. Adjust Targets: In the .bazelproject file that launches, specify one or more target patterns to be included in the sync scope
+2. Adjust Scope: In the .bazelproject file that launches, specify one or more directories or target patterns to be included in the sync scope
 3. Click the "Refresh Tests" Button:  Wait for the sync process to complete.
 
    ![image](https://github.com/uber/vscode-bazel-bsp/assets/92764374/bdbf80ad-485f-464b-b728-cdd86c42f0e5)
@@ -121,5 +122,4 @@ To run with coverage, use the "Run with Coverage" option appearing next to the r
   ![image](https://github.com/uber/vscode-bazel-bsp/assets/92764374/d9c376b8-74e8-4981-a400-ae2fb70ec2ae)
 
 - If a test is located under a different root node, or none, it may be coming a different extension.
-
 

--- a/package.json
+++ b/package.json
@@ -80,6 +80,15 @@
           ],
           "description": "Installation behavior for the build server."
         },
+        "bazelbsp.projectViewScopeDirectoryMinDepth": {
+          "type": [
+            "number",
+            "null"
+          ],
+          "default": null,
+          "minimum": 1,
+          "description": "Minimum number of workspace path segments under the repository root required to generate a project view scope from the opened workspace folder. Leave unset to use the manual placeholder target."
+        },
         "bazelbsp.autoExpandTarget": {
           "type": "boolean",
           "default": true,

--- a/src/server/install.ts
+++ b/src/server/install.ts
@@ -32,7 +32,7 @@ export interface InstallConfig {
   bazelProjectFilePath: string
   serverVersion: string
   bazelBinaryPath: string
-  projectViewDirectory: string
+  projectViewDirectory?: string
 }
 
 export class BazelBSPInstaller {
@@ -185,9 +185,13 @@ export class BazelBSPInstaller {
       // Set Bazel project details to be used if a project file is not already present.
       `--project-view-file "${config.bazelProjectFilePath}"`,
       `--bazel-binary "${bazelPath}"`,
-      `--directories "${config.projectViewDirectory}"`,
-      '--derive-targets-from-directories',
     ]
+    if (config.projectViewDirectory) {
+      installFlags.push(
+        `--directories "${config.projectViewDirectory}"`,
+        '--derive-targets-from-directories'
+      )
+    }
 
     const flagsString = installFlags.join(' ')
     const additionalInstallFlags = getExtensionSetting(
@@ -272,10 +276,10 @@ export class BazelBSPInstaller {
     }
   }
 
-  private getProjectViewDirectory(root: string): string {
+  private getProjectViewDirectory(root: string): string | undefined {
     const workspaceRoot = Utils.getWorkspaceRoot()
     if (!workspaceRoot) {
-      return '.'
+      return undefined
     }
 
     const relativePath = path.relative(root, workspaceRoot.fsPath)
@@ -284,10 +288,15 @@ export class BazelBSPInstaller {
       relativePath.startsWith('..') ||
       path.isAbsolute(relativePath)
     ) {
-      return '.'
+      return undefined
     }
 
-    return relativePath.split(path.sep).join('/')
+    const pathSegments = relativePath.split(path.sep).filter(Boolean)
+    if (pathSegments.length < 2) {
+      return undefined
+    }
+
+    return pathSegments.join('/')
   }
 
   /**

--- a/src/server/install.ts
+++ b/src/server/install.ts
@@ -32,6 +32,7 @@ export interface InstallConfig {
   bazelProjectFilePath: string
   serverVersion: string
   bazelBinaryPath: string
+  projectViewDirectory: string
 }
 
 export class BazelBSPInstaller {
@@ -86,7 +87,7 @@ export class BazelBSPInstaller {
       return false
     }
 
-    const installConfig = await this.getInstallConfig()
+    const installConfig = await this.getInstallConfig(root)
     if (!installConfig) {
       this.outputChannel.appendLine(
         'Installation interrupted: failed to get settings.'
@@ -180,16 +181,15 @@ export class BazelBSPInstaller {
 
     // Flags to be passed to the installer.
     // See CliOptionsProvider in the server code for available options.
-    const installFlags: Map<string, string> = new Map([
+    const installFlags = [
       // Set Bazel project details to be used if a project file is not already present.
-      ['--project-view-file', config.bazelProjectFilePath],
-      ['--bazel-binary', bazelPath],
-      ['--targets', '//your/targets/here/...'],
-    ])
+      `--project-view-file "${config.bazelProjectFilePath}"`,
+      `--bazel-binary "${bazelPath}"`,
+      `--directories "${config.projectViewDirectory}"`,
+      '--derive-targets-from-directories',
+    ]
 
-    const flagsString = Array.from(installFlags.entries())
-      .map(([key, value]) => `${key} "${value}"`)
-      .join(' ')
+    const flagsString = installFlags.join(' ')
     const additionalInstallFlags = getExtensionSetting(
       SettingName.ADDITIONAL_INSTALL_FLAGS
     )
@@ -226,7 +226,7 @@ export class BazelBSPInstaller {
     })
   }
 
-  private async getInstallConfig(): Promise<InstallConfig | null> {
+  private async getInstallConfig(root: string): Promise<InstallConfig | null> {
     const settingError = (setting: SettingName) => {
       this.outputChannel.appendLine(
         `Install interrupted. Please check the ${setting} setting to ensure a valid value.`
@@ -268,7 +268,26 @@ export class BazelBSPInstaller {
       bazelProjectFilePath: projectFilePath,
       serverVersion: bazelBspVersion,
       bazelBinaryPath: bazelBinaryPath,
+      projectViewDirectory: this.getProjectViewDirectory(root),
     }
+  }
+
+  private getProjectViewDirectory(root: string): string {
+    const workspaceRoot = Utils.getWorkspaceRoot()
+    if (!workspaceRoot) {
+      return '.'
+    }
+
+    const relativePath = path.relative(root, workspaceRoot.fsPath)
+    if (
+      relativePath === '' ||
+      relativePath.startsWith('..') ||
+      path.isAbsolute(relativePath)
+    ) {
+      return '.'
+    }
+
+    return relativePath.split(path.sep).join('/')
   }
 
   /**

--- a/src/server/install.ts
+++ b/src/server/install.ts
@@ -32,7 +32,7 @@ export interface InstallConfig {
   bazelProjectFilePath: string
   serverVersion: string
   bazelBinaryPath: string
-  projectViewDirectory?: string
+  projectViewScopeDirectory?: string
 }
 
 export class BazelBSPInstaller {
@@ -181,19 +181,25 @@ export class BazelBSPInstaller {
 
     // Flags to be passed to the installer.
     // See CliOptionsProvider in the server code for available options.
-    const installFlags = [
+    const installFlags: Map<string, string> = new Map([
       // Set Bazel project details to be used if a project file is not already present.
-      `--project-view-file "${config.bazelProjectFilePath}"`,
-      `--bazel-binary "${bazelPath}"`,
-    ]
-    if (config.projectViewDirectory) {
-      installFlags.push(
-        `--directories "${config.projectViewDirectory}"`,
-        '--derive-targets-from-directories'
-      )
+      ['--project-view-file', config.bazelProjectFilePath],
+      ['--bazel-binary', bazelPath],
+    ])
+    const installFlagSwitches: string[] = []
+    if (config.projectViewScopeDirectory) {
+      installFlags.set('--directories', config.projectViewScopeDirectory)
+      installFlagSwitches.push('--derive-targets-from-directories')
+    } else {
+      installFlags.set('--targets', '//your/targets/here/...')
     }
 
-    const flagsString = installFlags.join(' ')
+    const flagsString = [
+      ...Array.from(installFlags.entries()).map(
+        ([key, value]) => `${key} "${value}"`
+      ),
+      ...installFlagSwitches,
+    ].join(' ')
     const additionalInstallFlags = getExtensionSetting(
       SettingName.ADDITIONAL_INSTALL_FLAGS
     )
@@ -272,11 +278,11 @@ export class BazelBSPInstaller {
       bazelProjectFilePath: projectFilePath,
       serverVersion: bazelBspVersion,
       bazelBinaryPath: bazelBinaryPath,
-      projectViewDirectory: this.getProjectViewDirectory(root),
+      projectViewScopeDirectory: this.getProjectViewScopeDirectory(root),
     }
   }
 
-  private getProjectViewDirectory(root: string): string | undefined {
+  private getProjectViewScopeDirectory(root: string): string | undefined {
     const workspaceRoot = Utils.getWorkspaceRoot()
     if (!workspaceRoot) {
       return undefined

--- a/src/server/install.ts
+++ b/src/server/install.ts
@@ -278,11 +278,21 @@ export class BazelBSPInstaller {
       bazelProjectFilePath: projectFilePath,
       serverVersion: bazelBspVersion,
       bazelBinaryPath: bazelBinaryPath,
-      projectViewScopeDirectory: this.getProjectViewScopeDirectory(root),
+      projectViewScopeDirectory: this.getProjectViewScopeDirectory(
+        root,
+        getExtensionSetting(SettingName.PROJECT_VIEW_SCOPE_DIRECTORY_MIN_DEPTH)
+      ),
     }
   }
 
-  private getProjectViewScopeDirectory(root: string): string | undefined {
+  private getProjectViewScopeDirectory(
+    root: string,
+    minDepth: number | null | undefined
+  ): string | undefined {
+    if (minDepth === undefined || minDepth === null || minDepth < 1) {
+      return undefined
+    }
+
     const workspaceRoot = Utils.getWorkspaceRoot()
     if (!workspaceRoot) {
       return undefined
@@ -298,7 +308,7 @@ export class BazelBSPInstaller {
     }
 
     const pathSegments = relativePath.split(path.sep).filter(Boolean)
-    if (pathSegments.length < 2) {
+    if (pathSegments.length < minDepth) {
       return undefined
     }
 

--- a/src/test/suite/install.test.ts
+++ b/src/test/suite/install.test.ts
@@ -31,6 +31,7 @@ suite('BSP Installer', () => {
     isGzipped: boolean
     javaVersion: string
     additionalInstallFlags?: string[]
+    projectViewScopeDirectoryMinDepth?: number | null
   }
 
   const setupInstallTest = (config: InstallTestConfig) => {
@@ -54,6 +55,8 @@ suite('BSP Installer', () => {
       .returns('Prompt')
       .withArgs(settings.SettingName.ADDITIONAL_INSTALL_FLAGS)
       .returns(config.additionalInstallFlags || [])
+      .withArgs(settings.SettingName.PROJECT_VIEW_SCOPE_DIRECTORY_MIN_DEPTH)
+      .returns(config.projectViewScopeDirectoryMinDepth ?? null)
 
     sandbox.stub(fs, 'readFile').resolves(
       `#if( $pythonEnabled == "true" && $bazel8OrAbove == "true" )
@@ -179,8 +182,11 @@ load("//aspects:utils/utils.bzl", "create_struct", "file_location", "to_file_loc
     })
   })
 
-  test('uses workspace folder as generated project directory', async () => {
-    setupInstallTest(testConfigs.macArm64)
+  test('uses workspace folder as generated project directory when min depth is configured', async () => {
+    setupInstallTest({
+      ...testConfigs.macArm64,
+      projectViewScopeDirectoryMinDepth: 2,
+    })
     sandbox
       .stub(Utils, 'getWorkspaceRoot')
       .returns(vscode.Uri.file('/repo/root/packages/service'))
@@ -194,8 +200,26 @@ load("//aspects:utils/utils.bzl", "create_struct", "file_location", "to_file_loc
     assert.ok(!commandString.includes('--targets'))
   })
 
-  test('does not derive targets from repo root workspace', async () => {
+  test('does not derive targets when min depth is unset', async () => {
     setupInstallTest(testConfigs.macArm64)
+    sandbox
+      .stub(Utils, 'getWorkspaceRoot')
+      .returns(vscode.Uri.file('/repo/root/packages/service'))
+
+    await bazelBSPInstaller.install()
+
+    assert.equal(spawnStub.callCount, 1)
+    const commandString = spawnStub.getCalls()[0].args[0]
+    assert.ok(!commandString.includes('--directories "packages/service"'))
+    assert.ok(!commandString.includes('--derive-targets-from-directories'))
+    assert.ok(commandString.includes('--targets "//your/targets/here/..."'))
+  })
+
+  test('does not derive targets from repo root workspace', async () => {
+    setupInstallTest({
+      ...testConfigs.macArm64,
+      projectViewScopeDirectoryMinDepth: 2,
+    })
     sandbox
       .stub(Utils, 'getWorkspaceRoot')
       .returns(vscode.Uri.file('/repo/root'))
@@ -210,7 +234,10 @@ load("//aspects:utils/utils.bzl", "create_struct", "file_location", "to_file_loc
   })
 
   test('does not derive targets from top-level workspace directory', async () => {
-    setupInstallTest(testConfigs.macArm64)
+    setupInstallTest({
+      ...testConfigs.macArm64,
+      projectViewScopeDirectoryMinDepth: 2,
+    })
     sandbox
       .stub(Utils, 'getWorkspaceRoot')
       .returns(vscode.Uri.file('/repo/root/src'))

--- a/src/test/suite/install.test.ts
+++ b/src/test/suite/install.test.ts
@@ -164,8 +164,10 @@ load("//aspects:utils/utils.bzl", "create_struct", "file_location", "to_file_loc
       assert.ok(spawnCall.args[0].includes(coursierPath))
       assert.ok(spawnCall.args[0].includes(`--jvm ${config.javaVersion}`))
       assert.ok(spawnCall.args[0].includes('org.virtuslab:bazel-bsp:2.0.0'))
-      assert.ok(spawnCall.args[0].includes('--directories "."'))
-      assert.ok(spawnCall.args[0].includes('--derive-targets-from-directories'))
+      assert.ok(!spawnCall.args[0].includes('--directories'))
+      assert.ok(
+        !spawnCall.args[0].includes('--derive-targets-from-directories')
+      )
       assert.ok(!spawnCall.args[0].includes('--targets'))
       assert.deepStrictEqual(spawnCall.args[1], {
         cwd: '/repo/root',
@@ -187,6 +189,36 @@ load("//aspects:utils/utils.bzl", "create_struct", "file_location", "to_file_loc
     const commandString = spawnStub.getCalls()[0].args[0]
     assert.ok(commandString.includes('--directories "packages/service"'))
     assert.ok(commandString.includes('--derive-targets-from-directories'))
+    assert.ok(!commandString.includes('--targets'))
+  })
+
+  test('does not derive targets from repo root workspace', async () => {
+    setupInstallTest(testConfigs.macArm64)
+    sandbox
+      .stub(Utils, 'getWorkspaceRoot')
+      .returns(vscode.Uri.file('/repo/root'))
+
+    await bazelBSPInstaller.install()
+
+    assert.equal(spawnStub.callCount, 1)
+    const commandString = spawnStub.getCalls()[0].args[0]
+    assert.ok(!commandString.includes('--directories "."'))
+    assert.ok(!commandString.includes('--derive-targets-from-directories'))
+    assert.ok(!commandString.includes('--targets'))
+  })
+
+  test('does not derive targets from top-level workspace directory', async () => {
+    setupInstallTest(testConfigs.macArm64)
+    sandbox
+      .stub(Utils, 'getWorkspaceRoot')
+      .returns(vscode.Uri.file('/repo/root/src'))
+
+    await bazelBSPInstaller.install()
+
+    assert.equal(spawnStub.callCount, 1)
+    const commandString = spawnStub.getCalls()[0].args[0]
+    assert.ok(!commandString.includes('--directories "src"'))
+    assert.ok(!commandString.includes('--derive-targets-from-directories'))
     assert.ok(!commandString.includes('--targets'))
   })
 

--- a/src/test/suite/install.test.ts
+++ b/src/test/suite/install.test.ts
@@ -164,12 +164,30 @@ load("//aspects:utils/utils.bzl", "create_struct", "file_location", "to_file_loc
       assert.ok(spawnCall.args[0].includes(coursierPath))
       assert.ok(spawnCall.args[0].includes(`--jvm ${config.javaVersion}`))
       assert.ok(spawnCall.args[0].includes('org.virtuslab:bazel-bsp:2.0.0'))
+      assert.ok(spawnCall.args[0].includes('--directories "."'))
+      assert.ok(spawnCall.args[0].includes('--derive-targets-from-directories'))
+      assert.ok(!spawnCall.args[0].includes('--targets'))
       assert.deepStrictEqual(spawnCall.args[1], {
         cwd: '/repo/root',
         shell: true,
       })
       assert.ok(installResult)
     })
+  })
+
+  test('uses workspace folder as generated project directory', async () => {
+    setupInstallTest(testConfigs.macArm64)
+    sandbox
+      .stub(Utils, 'getWorkspaceRoot')
+      .returns(vscode.Uri.file('/repo/root/packages/service'))
+
+    await bazelBSPInstaller.install()
+
+    assert.equal(spawnStub.callCount, 1)
+    const commandString = spawnStub.getCalls()[0].args[0]
+    assert.ok(commandString.includes('--directories "packages/service"'))
+    assert.ok(commandString.includes('--derive-targets-from-directories'))
+    assert.ok(!commandString.includes('--targets'))
   })
 
   test('failed coursier download', async () => {

--- a/src/test/suite/install.test.ts
+++ b/src/test/suite/install.test.ts
@@ -168,7 +168,9 @@ load("//aspects:utils/utils.bzl", "create_struct", "file_location", "to_file_loc
       assert.ok(
         !spawnCall.args[0].includes('--derive-targets-from-directories')
       )
-      assert.ok(!spawnCall.args[0].includes('--targets'))
+      assert.ok(
+        spawnCall.args[0].includes('--targets "//your/targets/here/..."')
+      )
       assert.deepStrictEqual(spawnCall.args[1], {
         cwd: '/repo/root',
         shell: true,
@@ -204,7 +206,7 @@ load("//aspects:utils/utils.bzl", "create_struct", "file_location", "to_file_loc
     const commandString = spawnStub.getCalls()[0].args[0]
     assert.ok(!commandString.includes('--directories "."'))
     assert.ok(!commandString.includes('--derive-targets-from-directories'))
-    assert.ok(!commandString.includes('--targets'))
+    assert.ok(commandString.includes('--targets "//your/targets/here/..."'))
   })
 
   test('does not derive targets from top-level workspace directory', async () => {
@@ -219,7 +221,7 @@ load("//aspects:utils/utils.bzl", "create_struct", "file_location", "to_file_loc
     const commandString = spawnStub.getCalls()[0].args[0]
     assert.ok(!commandString.includes('--directories "src"'))
     assert.ok(!commandString.includes('--derive-targets-from-directories'))
-    assert.ok(!commandString.includes('--targets'))
+    assert.ok(commandString.includes('--targets "//your/targets/here/..."'))
   })
 
   test('failed coursier download', async () => {

--- a/src/utils/settings.ts
+++ b/src/utils/settings.ts
@@ -8,6 +8,7 @@ export enum SettingName {
   BSP_SERVER_VERSION = 'serverVersion',
   BAZEL_BINARY_PATH = 'bazelBinaryPath',
   SERVER_INSTALL_MODE = 'serverInstallMode',
+  PROJECT_VIEW_SCOPE_DIRECTORY_MIN_DEPTH = 'projectViewScopeDirectoryMinDepth',
   AUTO_EXPAND_TARGET = 'autoExpandTarget',
   DEBUG_ENABLED = 'debug.enabled',
   DEBUG_BAZEL_FLAGS = 'debug.bazelFlags',
@@ -23,6 +24,7 @@ export interface SettingTypes {
   [SettingName.BSP_SERVER_VERSION]: string
   [SettingName.BAZEL_BINARY_PATH]: string
   [SettingName.SERVER_INSTALL_MODE]: string
+  [SettingName.PROJECT_VIEW_SCOPE_DIRECTORY_MIN_DEPTH]: number | null
   [SettingName.AUTO_EXPAND_TARGET]: boolean
   [SettingName.DEBUG_ENABLED]: boolean
   [SettingName.DEBUG_BAZEL_FLAGS]: string[]


### PR DESCRIPTION
## Problem
The installer generated a project view with a placeholder target pattern. That made the default setup unusable until users opened the generated project view, replaced the placeholder manually, and refreshed the Test Explorer. In large repositories, opening a nested workspace can produce a scoped default when that behavior is explicitly enabled for the repo or user.

## Summary
- add `bazelbsp.projectViewScopeDirectoryMinDepth` to opt into generating project views from the opened workspace folder
- when enabled and the opened workspace is deep enough, generate `directories` and `derive_targets_from_directories`
- when unset, or when the workspace is too broad, keep the manual `--targets "//your/targets/here/..."` placeholder
- update setup docs to describe manual scope editing and the opt-in workspace scope setting

## Test plan
- yarn test-compile
- yarn lint:single src/server/install.ts src/test/suite/install.test.ts src/utils/settings.ts
- git diff --check