### PR TITLE
Bump Bazel BSP server to 4.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "displayName": "Bazel Build Server Protocol (BSP)",
   "description": "Bazel BSP integration for VS Code.",
   "publisher": "Uber",
-  "version": "0.0.19",
+  "version": "0.0.20",
   "license": "Apache-2.0",
   "repository": "https://github.com/uber/vscode-bazel-bsp",
   "engines": {
@@ -57,7 +57,7 @@
         },
         "bazelbsp.serverVersion": {
           "type": "string",
-          "default": "4.0.4",
+          "default": "4.0.5",
           "description": "Version of the Bazel BSP server to install."
         },
         "bazelbsp.bazelBinaryPath": {


### PR DESCRIPTION
## Problem
The extension still defaults to Bazel BSP server 4.0.4 even though 4.0.5 is available.

## Summary
- bump the extension package version to 0.0.20
- update the default Bazel BSP server version from 4.0.4 to 4.0.5

## Test plan
- verified that Bazel BSP 4.0.5 is published and available from [Maven Central](https://central.sonatype.com/artifact/org.virtuslab/bazel-bsp/versions)
- verified the updated package.json values in the branch before pushing